### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-18 - Missing ARIA Labels on Icon-Only Buttons
+**Learning:** The codebase heavily relies on `consts.SOME_MARK` (icon spans) inside buttons without providing accessible names. This makes the app unusable for screen reader users as they only hear "button" or "add" (if the icon uses ligatures).
+**Action:** Systematically audit all `btn-icon` usages and enforce `aria-label` when the button content is purely graphical.

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+**/dist/

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,7 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add task"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,7 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Copy node ID"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,7 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Restore to Todo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,7 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +78,7 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -15,6 +15,7 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Evaluate"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -109,6 +109,7 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Show details"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,7 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start task"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,7 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start task concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as Done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as Won't Do"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,7 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to 11 icon-only buttons across the application (Add, Start, Stop, Copy, Move, etc.).
🎯 Why: Screen reader users could not identify these buttons as they only contained icon spans (e.g., `<span class="material-icons">add</span>`).
♿ Accessibility: Ensures all interactive elements have accessible names.
Also updated `.gitignore` to ignore `dist/` folders and added a UX journal entry in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [10699922238322062387](https://jules.google.com/task/10699922238322062387) started by @kshramt*