### PR TITLE
🛡️ Sentinel: [medium] Add security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2024-05-23 - Insecure Authentication Mechanism
+**Vulnerability:** The application uses a "Fake IDP" system where authentication tokens are simple Base64-encoded JSON objects (e.g., `{"user_id": "..."}`) without any cryptographic signature or verification.
+**Learning:** This likely exists as a development shortcut that was not replaced with a production-ready solution. It allows complete account takeover by forging tokens.
+**Prevention:** Always use standard, cryptographically secure authentication methods (OIDC, JWT with signatures) even in early development, or strictly enforce "dev-only" flags that prevent insecure auth in production builds.
+
+## 2024-05-23 - Missing Security Headers in Axum
+**Vulnerability:** The Axum backend was missing standard security headers (X-Frame-Options, X-Content-Type-Options, X-XSS-Protection), leaving it vulnerable to clickjacking and MIME sniffing.
+**Learning:** Axum/Tower does not enable these headers by default. `tower_http::set_header` must be manually configured.
+**Prevention:** Use a standard security middleware stack (like `tower_http`'s `SetResponseHeaderLayer`) in the application entry point for all new services.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{header::HeaderName, request::Parts, HeaderValue},
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -13,6 +13,7 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
@@ -378,6 +379,23 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-content-type-options"),
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-frame-options"),
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-xss-protection"),
+            HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -388,9 +406,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +416,34 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::get,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = Router::new().route("/", get(|| async { "Hello, world!" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let headers = response.headers();
+        assert_eq!(headers.get("x-content-type-options").unwrap(), "nosniff");
+        assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(headers.get("x-xss-protection").unwrap(), "1; mode=block");
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel Report

🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard security headers in the backend API (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection).
🎯 Impact: Increases risk of MIME sniffing, clickjacking, and XSS attacks.
🔧 Fix: Implemented `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs` to enforce these headers. Refactored middleware setup into `apply_middleware` for better testing.
✅ Verification: Added unit test `test_security_headers` in `api_v2/src/main.rs` verifying headers are present.

---
*PR created automatically by Jules for task [11655915631625406983](https://jules.google.com/task/11655915631625406983) started by @kshramt*