### PR TITLE
⚡ Bolt: Memoize QueueEntry to reduce re-renders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+**/dist/
+**/dev-dist/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-01-27 - React Virtuoso and Memoization
+**Learning:** Components rendered by `react-virtuoso` (like `QueueEntry`) must be explicitly wrapped in `React.memo`. Even with `react-compiler` or other optimizations, the parent-triggered re-renders from the virtualization library can cause performance issues if items are not memoized.
+**Action:** Always wrap `itemContent` components in `React.memo` when using `react-virtuoso`.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,8 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+// Bolt: Memoized to prevent unnecessary re-renders when rendered by react-virtuoso
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +30,7 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` in `React.memo` and added `**/dist/` to `.gitignore`.
🎯 Why: `QueueEntry` is used in a virtualized list (`react-virtuoso`). Without memoization, list items re-render unnecessarily when the list container updates or scrolls, causing performance degradation.
📊 Impact: Reduces unnecessary re-renders of list items, improving scrolling performance and responsiveness.
🔬 Measurement: Verified by build and lint checks. Visual verification would require a running backend with data.

---
*PR created automatically by Jules for task [14908617197449649964](https://jules.google.com/task/14908617197449649964) started by @kshramt*