### PR TITLE
🎨 Palette: Add accessibility labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-28 - Missing ARIA Labels on Icon-only Buttons
+**Learning:** The codebase heavily utilizes icon-only buttons for core actions (add, start, stop, etc.) without accompanying text labels or ARIA attributes. This renders the application largely unusable for screen reader users and confusing for users who may not understand the icons (as there are no tooltips).
+**Action:** When creating or modifying icon-only buttons, always enforce the presence of `aria-label` and `title` attributes. This pattern should be checked during code review.

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+
+**/dist/
+**/dev-dist/
+*.log

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add item"
+      title="Add item"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/Calendar/AddButton.tsx
+++ b/client/src/Calendar/AddButton.tsx
@@ -19,7 +19,12 @@ const AddButton = (props: { timeId: string }) => {
     );
   }, [dispatch, props.timeId, nodeIds]);
   return (
-    <button className="btn-icon" onClick={handleClick}>
+    <button
+      className="btn-icon"
+      onClick={handleClick}
+      aria-label="Add to schedule"
+      title="Add to schedule"
+    >
       {consts.ADD_MARK}
     </button>
   );

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -25,6 +25,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Copy Node ID"
+      title="Copy Node ID"
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -17,6 +17,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Evaluate"
+      title="Evaluate"
     >
       {consts.EVAL_MARK}
     </button>

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -111,6 +111,8 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Show details"
+      title="Show details"
     >
       {consts.DETAIL_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrently"
+      title="Start concurrently"
     >
       {consts.START_CONCURRNET_MARK}
     </button>

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -16,6 +16,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}
+      aria-label="Move to top"
+      title="Move to top"
     >
       {consts.TOP_MARK}
     </button>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to icon-only buttons (`AddButton`, `StartButton`, `StartConcurrentButton`, `TopButton`, `EvalButton`, `ShowDetailsButton`, `CopyNodeIdButton`).
🎯 Why: These buttons relied solely on visual icons (ligatures) without accessible names, making them unusable for screen reader users and lacking tooltips for sighted users.
♿ Accessibility: Ensures all interactive elements have accessible names and provides tooltips on hover.
📝 Journal: Recorded findings in `.Jules/palette.md`.
🔧 Misc: Updated `.gitignore` to include `dist`, `dev-dist`, and logs.

---
*PR created automatically by Jules for task [8922955277879268564](https://jules.google.com/task/8922955277879268564) started by @kshramt*