### PR TITLE
🛡️ Sentinel: [HIGH] Add security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - Insecure Fake IDP Authentication
+**Vulnerability:** The application uses an insecure "Fake IDP" authentication mechanism where `IdToken` is simply a Base64-encoded JSON object containing a `user_id`, without any cryptographic signature or verification.
+**Learning:** This mechanism allows trivial impersonation by encoding an arbitrary `user_id`. It likely exists to facilitate easy testing and development without a real identity provider, but it poses a critical risk if exposed or used in any environment resembling production.
+**Prevention:** Ensure that `fake_idp` endpoints are strictly isolated to development environments and never exposed to public networks. For any non-development deployment, replace this mechanism with a standard, cryptographically secure authentication scheme (e.g., OIDC, JWT with valid signatures).

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,5 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
+    http::{HeaderName, HeaderValue},
     http::request::Parts,
     Json, RequestPartsExt,
 };
@@ -7,6 +8,7 @@ use axum_extra::{
     headers::{authorization::Bearer, Authorization},
     TypedHeader,
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use base64::Engine;
 use serde_json::json;
 use std::{
@@ -378,6 +380,23 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-content-type-options"),
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-frame-options"),
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-xss-protection"),
+            HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -388,9 +407,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +417,29 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::{Request, StatusCode}, routing::get};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = axum::Router::new().route("/", get(|| async { "ok" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let headers = response.headers();
+
+        assert_eq!(headers.get("x-content-type-options").unwrap(), "nosniff");
+        assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(headers.get("x-xss-protection").unwrap(), "1; mode=block");
+    }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing security headers (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection).
🎯 Impact: Increases risk of MIME sniffing, Clickjacking, and XSS attacks.
🔧 Fix: Added `tower_http::set_header::SetResponseHeaderLayer` to `api_v2/src/main.rs` to enforce these headers.
✅ Verification: Added `test_security_headers` unit test in `api_v2/src/main.rs` which verifies the headers are present. Verified with `cargo test -p api_v2`.

Also added a critical learning about insecure "Fake IDP" authentication to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9101969908254390208](https://jules.google.com/task/9101969908254390208) started by @kshramt*