### PR TITLE
🎨 Palette: Accessible Icon-Only Buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+**/dist/

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add."
+      title="Add."
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -25,6 +25,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label={is_copied ? "Copied." : "Copy node ID."}
+      title={is_copied ? "Copied." : "Copy node ID."}
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -16,6 +16,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Mark as to do."
+      title="Mark as to do."
     >
       {consts.UNDO_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up."
+      title="Move up."
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down."
+      title="Move down."
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -17,6 +17,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Evaluate."
+      title="Evaluate."
     >
       {consts.EVAL_MARK}
     </button>

--- a/client/src/Header/MenuButton/index.tsx
+++ b/client/src/Header/MenuButton/index.tsx
@@ -49,6 +49,8 @@ const MenuButton = (props: {
           ref={menuButtonRef}
           onClick={handleButtonClick}
           className="btn-icon"
+          aria-label="Menu."
+          title="Menu."
         >
           <span className="material-icons">menu</span>
         </button>

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -111,6 +111,8 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Show details."
+      title="Show details."
     >
       {consts.DETAIL_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start."
+      title="Start."
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrent."
+      title="Start concurrent."
     >
       {consts.START_CONCURRNET_MARK}
     </button>

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Mark as done."
+      title="Mark as done."
     >
       {consts.DONE_MARK}
     </button>

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Mark as won't do."
+      title="Mark as won't do."
     >
       {consts.DONT_MARK}
     </button>

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -16,6 +16,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}
+      aria-label="Move to top."
+      title="Move to top."
     >
       {consts.TOP_MARK}
     </button>

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -372,7 +372,9 @@ export const ToggleShowMobileButton = () => {
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
-      aria-label={show_mobile ? "Show desktop version." : "Show mobile version."}
+      aria-label={
+        show_mobile ? "Show desktop version." : "Show mobile version."
+      }
       title={show_mobile ? "Show desktop version." : "Show mobile version."}
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -110,6 +110,8 @@ const MobileNodeFilterQueryInput = () => {
         className="icon-icon"
         onClick={clear_input}
         onDoubleClick={prevent_propagation}
+        aria-label="Clear input."
+        title="Clear input."
       >
         {consts.DELETE_MARK}
       </button>
@@ -167,6 +169,8 @@ const NodeFilterQueryInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear input."
+          title="Clear input."
         >
           {consts.DELETE_MARK}
         </button>
@@ -315,6 +319,8 @@ const NodeIdsInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear input."
+          title="Clear input."
         >
           {consts.DELETE_MARK}
         </button>
@@ -328,6 +334,8 @@ const SBTTB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[60%] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to top."
+      title="Scroll to top."
     >
       {SCROLL_BACK_TO_TOP_MARK}
     </button>
@@ -339,6 +347,8 @@ const SBTBB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[calc(60%+4rem)] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to bottom."
+      title="Scroll to bottom."
     >
       {SCROLL_BACK_TO_BOTTOM_MARK}
     </button>
@@ -362,6 +372,8 @@ export const ToggleShowMobileButton = () => {
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
+      aria-label={show_mobile ? "Show desktop version." : "Show mobile version."}
+      title={show_mobile ? "Show desktop version." : "Show mobile version."}
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}
     </button>
@@ -424,6 +436,8 @@ const Menu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all."
+        title="Stop all."
       >
         {consts.STOP_MARK}
       </button>
@@ -431,6 +445,7 @@ const Menu = (props: {
       <button
         className="btn-icon"
         aria-label="Undo."
+        title="Undo."
         onClick={_undo}
         onDoubleClick={prevent_propagation}
       >
@@ -439,6 +454,7 @@ const Menu = (props: {
       <button
         className="btn-icon"
         aria-label="Redo."
+        title="Redo."
         onClick={_redo}
         onDoubleClick={prevent_propagation}
       >
@@ -578,7 +594,12 @@ const Timeline = () => {
   return (
     <>
       {decade_nodes}
-      <button className="btn-icon" onClick={increment_count}>
+      <button
+        className="btn-icon"
+        onClick={increment_count}
+        aria-label="Add decade."
+        title="Add decade."
+      >
         {consts.ADD_MARK}
       </button>
     </>
@@ -785,13 +806,23 @@ const TimeNodeEntry = (props: { time_node_id: types.TTimeNodeId }) => {
       />
       {isOn && (
         <div className="flex w-fit gap-x-[0.125em]">
-          <button className="btn-icon" onClick={assign_nodes}>
+          <button
+            className="btn-icon"
+            onClick={assign_nodes}
+            aria-label="Assign nodes."
+            title="Assign nodes."
+          >
             {consts.ADD_MARK}
           </button>
           <CopyDescendantTimeNodesPlannedNodeIdsButton
             time_node_id={props.time_node_id}
           />
-          <button className="btn-icon" onClick={toggle_show_children}>
+          <button
+            className="btn-icon"
+            onClick={toggle_show_children}
+            aria-label="Toggle children."
+            title="Toggle children."
+          >
             {time_node === undefined || time_node.show_children === "partial"
               ? consts.IS_PARTIAL_MARK
               : time_node.show_children === "full"
@@ -863,7 +894,12 @@ const PlannedNode = (props: {
             </>
           )}
           <CopyNodeIdButton node_id={props.node_id} />
-          <button className="btn-icon" onClick={unassign_node}>
+          <button
+            className="btn-icon"
+            onClick={unassign_node}
+            aria-label="Unassign node."
+            title="Unassign node."
+          >
             {consts.DELETE_MARK}
           </button>
         </div>
@@ -1132,6 +1168,8 @@ const MobileMenu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all."
+        title="Stop all."
       >
         {consts.STOP_MARK}
       </button>
@@ -1139,6 +1177,7 @@ const MobileMenu = (props: {
       <button
         className="btn-icon"
         aria-label="Undo."
+        title="Undo."
         onClick={_undo}
         onDoubleClick={prevent_propagation}
       >
@@ -1147,6 +1186,7 @@ const MobileMenu = (props: {
       <button
         className="btn-icon"
         aria-label="Redo."
+        title="Redo."
         onClick={_redo}
         onDoubleClick={prevent_propagation}
       >
@@ -1457,6 +1497,8 @@ const CopyDescendantTimeNodesPlannedNodeIdsButton = (props: {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={prevent_propagation}
+      aria-label={is_copied ? "Copied." : "Copy node ID."}
+      title={is_copied ? "Copied." : "Copy node ID."}
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `title` attributes to all identified icon-only buttons in the frontend application.
🎯 **Why**: To improve accessibility for screen reader users (who previously only heard "button" or the icon text like "add") and to provide helpful tooltips for all users.
♿ **Accessibility**:
- Screen readers now announce the purpose of buttons (e.g., "Add.", "Show details.", "Move to top.").
- Buttons now have text alternatives for visual icons.
- Tooltips are provided via the `title` attribute.
🔧 **Maintenance**:
- Added `**/dist/` to `.gitignore` to prevent accidental commit of build artifacts.

---
*PR created automatically by Jules for task [8435334248824384066](https://jules.google.com/task/8435334248824384066) started by @kshramt*