### PR TITLE
⚡ Bolt: Optimize QueueEntry re-renders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+**/dist/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-01-29 - React Virtualization Performance
+**Learning:** Components rendered by `react-virtuoso` via `itemContent` should be wrapped in `React.memo` to prevent unnecessary re-renders when the list container updates or scrolls.
+**Action:** Always wrap row components in virtualized lists with `React.memo` unless they are extremely lightweight.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -18,123 +18,125 @@ import * as utils from "./utils";
 import TopButton from "./TopButton";
 
 // Bolt: Wrapped in React.memo to prevent unnecessary re-renders in virtualized list (react-virtuoso)
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 // Bolt: Wrapped in React.memo
-const _QueueEntry = React.memo((props: { node_id: types.TNodeId; index: number }) => {
-  const isTodo =
-    utils.assertV(
+const _QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const isTodo =
+      utils.assertV(
+        useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
+      ) === "todo";
+
+    return isTodo ? (
+      <TodoQueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <NonTodoQueueEntry node_id={props.node_id} index={props.index} />
+    );
+  },
+);
+
+// Bolt: Wrapped in React.memo
+const NonTodoQueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const status = utils.assertV(
       useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
-    ) === "todo";
+    );
+    const to_tree = utils.useToTree(props.node_id);
+    const handleKeyDown = hooks.useTaskShortcutKeys(
+      props.node_id,
+      consts.TREE_PREFIX,
+    );
+    const id = utils.queue_textarea_id_of(props.node_id);
 
-  return isTodo ? (
-    <TodoQueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <NonTodoQueueEntry node_id={props.node_id} index={props.index} />
-  );
-});
-
-// Bolt: Wrapped in React.memo
-const NonTodoQueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const status = utils.assertV(
-    useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
-  );
-  const to_tree = utils.useToTree(props.node_id);
-  const handleKeyDown = hooks.useTaskShortcutKeys(
-    props.node_id,
-    consts.TREE_PREFIX,
-  );
-  const id = utils.queue_textarea_id_of(props.node_id);
-
-  return (
-    <EntryWrapper node_id={props.node_id} component="div">
-      <div className="flex items-end w-fit">
-        <TextArea
-          node_id={props.node_id}
-          id={id}
-          className={utils.join(
-            "w-[29em] px-[0.75em] py-[0.5em]",
-            status === "done"
-              ? "text-red-600 dark:text-red-400"
-              : status === "dont"
-                ? "text-neutral-500"
-                : null,
-          )}
-          onKeyDown={handleKeyDown}
-        />
-        <EntryInfos node_id={props.node_id} />
-      </div>
-      <EntryButtons
-        node_id={props.node_id}
-        jumpButton={<button onClick={to_tree}>←</button>}
-      />
-    </EntryWrapper>
-  );
-});
-
-// Bolt: Wrapped in React.memo
-const TodoQueueEntry = React.memo((props: { node_id: types.TNodeId; index: number }) => {
-  const leaf_estimates_sum = utils.assertV(
-    useSelector(
-      (state) => state.swapped_caches.leaf_estimates_sum?.[props.node_id],
-    ),
-  );
-  const percentiles = utils.assertV(
-    useSelector((state) => state.swapped_caches.percentiles?.[props.node_id]),
-  );
-  const text = utils.assertV(
-    useSelector((state) => state.swapped_caches.text?.[props.node_id]),
-  );
-  const toTree = utils.useToTree(props.node_id);
-  const isRunning = utils.useIsRunning(props.node_id);
-
-  return (
-    <>
-      <div
-        className={utils.join(
-          "flex items-baseline gap-x-[0.25em] pb-[0.125em] w-[51em]",
-          isRunning && "running",
-        )}
-      >
-        <div className="flex items-baseline gap-x-[0.25em] w-[22em]">
-          <span className="w-[5em] text-right">{props.index}</span>
-          <TopButton node_id={props.node_id} />
-          <TodoToDoneButton node_id={props.node_id} />
-          <TodoToDontButton node_id={props.node_id} />
-          <ShowDetailsButton node_id={props.node_id} />
-          <CopyNodeIdButton node_id={props.node_id} />
-          <StartOrStopButtons node_id={props.node_id} />
+    return (
+      <EntryWrapper node_id={props.node_id} component="div">
+        <div className="flex items-end w-fit">
+          <TextArea
+            node_id={props.node_id}
+            id={id}
+            className={utils.join(
+              "w-[29em] px-[0.75em] py-[0.5em]",
+              status === "done"
+                ? "text-red-600 dark:text-red-400"
+                : status === "dont"
+                  ? "text-neutral-500"
+                  : null,
+            )}
+            onKeyDown={handleKeyDown}
+          />
+          <EntryInfos node_id={props.node_id} />
         </div>
-        <span
-          className="w-[16em] inline-block whitespace-nowrap overflow-hidden cursor-pointer"
-          title={text}
-          onClick={toTree}
-          role="button"
-          tabIndex={0}
+        <EntryButtons
+          node_id={props.node_id}
+          jumpButton={<button onClick={to_tree}>←</button>}
+        />
+      </EntryWrapper>
+    );
+  },
+);
+
+// Bolt: Wrapped in React.memo
+const TodoQueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const leaf_estimates_sum = utils.assertV(
+      useSelector(
+        (state) => state.swapped_caches.leaf_estimates_sum?.[props.node_id],
+      ),
+    );
+    const percentiles = utils.assertV(
+      useSelector((state) => state.swapped_caches.percentiles?.[props.node_id]),
+    );
+    const text = utils.assertV(
+      useSelector((state) => state.swapped_caches.text?.[props.node_id]),
+    );
+    const toTree = utils.useToTree(props.node_id);
+    const isRunning = utils.useIsRunning(props.node_id);
+
+    return (
+      <>
+        <div
+          className={utils.join(
+            "flex items-baseline gap-x-[0.25em] pb-[0.125em] w-[51em]",
+            isRunning && "running",
+          )}
         >
-          {text}
-        </span>
-        <EntryInfos node_id={props.node_id} />
-      </div>
-      <div>
-        {0 <= leaf_estimates_sum && utils.digits1(leaf_estimates_sum) + " | "}
-        {percentiles.map(utils.digits1).join(", ")}
-      </div>
-    </>
-  );
-});
+          <div className="flex items-baseline gap-x-[0.25em] w-[22em]">
+            <span className="w-[5em] text-right">{props.index}</span>
+            <TopButton node_id={props.node_id} />
+            <TodoToDoneButton node_id={props.node_id} />
+            <TodoToDontButton node_id={props.node_id} />
+            <ShowDetailsButton node_id={props.node_id} />
+            <CopyNodeIdButton node_id={props.node_id} />
+            <StartOrStopButtons node_id={props.node_id} />
+          </div>
+          <span
+            className="w-[16em] inline-block whitespace-nowrap overflow-hidden cursor-pointer"
+            title={text}
+            onClick={toTree}
+            role="button"
+            tabIndex={0}
+          >
+            {text}
+          </span>
+          <EntryInfos node_id={props.node_id} />
+        </div>
+        <div>
+          {0 <= leaf_estimates_sum && utils.digits1(leaf_estimates_sum) + " | "}
+          {percentiles.map(utils.digits1).join(", ")}
+        </div>
+      </>
+    );
+  },
+);

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,8 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+// Bolt: Wrapped in React.memo to prevent unnecessary re-renders in virtualized list (react-virtuoso)
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,9 +30,10 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
 
-const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
+// Bolt: Wrapped in React.memo
+const _QueueEntry = React.memo((props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =
     utils.assertV(
       useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
@@ -42,9 +44,10 @@ const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   ) : (
     <NonTodoQueueEntry node_id={props.node_id} index={props.index} />
   );
-};
+});
 
-const NonTodoQueueEntry = (props: {
+// Bolt: Wrapped in React.memo
+const NonTodoQueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -82,9 +85,10 @@ const NonTodoQueueEntry = (props: {
       />
     </EntryWrapper>
   );
-};
+});
 
-const TodoQueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
+// Bolt: Wrapped in React.memo
+const TodoQueueEntry = React.memo((props: { node_id: types.TNodeId; index: number }) => {
   const leaf_estimates_sum = utils.assertV(
     useSelector(
       (state) => state.swapped_caches.leaf_estimates_sum?.[props.node_id],
@@ -133,4 +137,4 @@ const TodoQueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
       </div>
     </>
   );
-};
+});


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` and its internal components (`_QueueEntry`, `TodoQueueEntry`, `NonTodoQueueEntry`) in `React.memo`.
🎯 Why: To prevent unnecessary re-renders of list items when the virtualized list container (`react-virtuoso`) re-renders or scrolls, improving performance.
📊 Impact: Reduces re-renders of list rows when props (`node_id`, `index`) are stable.
🔬 Measurement: Verified via build and code review. Added `.jules/bolt.md` entry. Added `**/dist/` to `.gitignore` to prevent artifact commit.

---
*PR created automatically by Jules for task [12988997102032647472](https://jules.google.com/task/12988997102032647472) started by @kshramt*