### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing security headers

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{request::Parts, HeaderName, HeaderValue},
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -378,6 +378,23 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-content-type-options"),
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-frame-options"),
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-xss-protection"),
+            HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -388,9 +405,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +415,49 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        Router,
+    };
+    use tower::ServiceExt; // for oneshot
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = Router::new().route("/", axum::routing::get(|| async { "ok" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let headers = response.headers();
+
+        assert_eq!(
+            headers
+                .get("x-content-type-options")
+                .and_then(|h| h.to_str().ok()),
+            Some("nosniff"),
+            "Missing or incorrect X-Content-Type-Options header"
+        );
+        assert_eq!(
+            headers.get("x-frame-options").and_then(|h| h.to_str().ok()),
+            Some("DENY"),
+            "Missing or incorrect X-Frame-Options header"
+        );
+        assert_eq!(
+            headers
+                .get("x-xss-protection")
+                .and_then(|h| h.to_str().ok()),
+            Some("1; mode=block"),
+            "Missing or incorrect X-XSS-Protection header"
+        );
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add missing security headers

**Vulnerability:** The backend was missing standard security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`), which could expose users to MIME sniffing, clickjacking, and XSS attacks.

**Impact:**
- **MIME Sniffing:** Browsers might incorrectly interpret files as executable scripts.
- **Clickjacking:** The application could be embedded in an iframe on a malicious site.
- **XSS:** Older browsers might not block reflected XSS attacks.

**Fix:**
- Implemented `tower_http::set_header::SetResponseHeaderLayer` in `api_v2` to inject these headers.
- Refactored `main.rs` to extract `apply_middleware` for better testability.

**Verification:**
- Added `test_security_headers` in `api_v2/src/main.rs` which verifies the headers are present on a dummy route.
- Ran `cargo test` in `api_v2` to confirm the test passes.

---
*PR created automatically by Jules for task [10563643984514556827](https://jules.google.com/task/10563643984514556827) started by @kshramt*