### PR TITLE
🎨 Palette: Improve accessibility of filter and ID inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Input and Icon-Only Button Accessibility
+**Learning:** Many input fields (like filters) lacked labels and placeholders, and their associated "clear" buttons were icon-only without `aria-label`. This made them hard to discover and use for screen reader users.
+**Action:** When creating or modifying inputs with icon-only controls, always add `aria-label` to the input (if a visible label isn't feasible) and `aria-label` + `title` to the buttons.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 # production
 **/build/
+**/dist/
+**/dev-dist/
 
 # misc
 .DS_Store

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -102,12 +102,16 @@ const MobileNodeFilterQueryInput = () => {
   return (
     <div className="flex items-center border border-solid border-neutral-400">
       <input
+        aria-label="Filter nodes"
+        placeholder="Filter nodes..."
         value={nodeFilterQuery}
         onChange={handle_change}
         className="h-[2em] border-none w-[8em]"
       />
       <button
-        className="icon-icon"
+        aria-label="Clear filter"
+        title="Clear filter"
+        className="btn-icon"
         onClick={clear_input}
         onDoubleClick={prevent_propagation}
       >
@@ -157,6 +161,8 @@ const NodeFilterQueryInput = () => {
       {consts.SEARCH_MARK}
       <div className="flex items-center border border-solid border-neutral-400">
         <input
+          aria-label="Filter nodes"
+          placeholder="Filter nodes..."
           value={nodeFilterQuery}
           onChange={handle_change}
           onKeyDown={onKeyDown}
@@ -164,6 +170,8 @@ const NodeFilterQueryInput = () => {
           ref={ref}
         />
         <button
+          aria-label="Clear filter"
+          title="Clear filter"
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
@@ -307,11 +315,15 @@ const NodeIdsInput = () => {
       {consts.IDS_MARK}
       <div className="flex items-center border border-solid border-neutral-400">
         <input
+          aria-label="Selected node IDs"
+          placeholder="Node IDs..."
           value={nodeIds}
           onChange={handle_change}
           className="h-[2em] border-none"
         />
         <button
+          aria-label="Clear node IDs"
+          title="Clear node IDs"
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}


### PR DESCRIPTION
💡 **What:**
- Added `aria-label`, `placeholder`, and `title` attributes to `NodeFilterQueryInput`, `MobileNodeFilterQueryInput`, and `NodeIdsInput` in `client/src/components.tsx`.
- Fixed a class name typo (`icon-icon` -> `btn-icon`) in `MobileNodeFilterQueryInput`.
- Updated `.gitignore` to explicitly ignore `dist/` and `dev-dist/` directories to prevent checking in build artifacts.
- Created `.Jules/palette.md` to record UX and accessibility learnings.

🎯 **Why:**
- The filter and ID input fields lacked visible placeholders and accessible labels, making them confusing for users and inaccessible to screen readers.
- The "clear" buttons were icon-only without text alternatives or tooltips.
- The repository was missing ignore rules for Vite build artifacts, leading to potential accidental commits of generated code.

♿ **Accessibility:**
- Screen readers will now announce "Filter nodes" or "Selected node IDs" when focusing the inputs.
- Screen readers will announce "Clear filter" or "Clear node IDs" for the buttons.
- Mouse users will see tooltips explaining the "clear" button's function.

---
*PR created automatically by Jules for task [12204917162430973500](https://jules.google.com/task/12204917162430973500) started by @kshramt*