### PR TITLE
🎨 Palette: Add accessible labels to AddButton

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-02 - Reusable Icon-Only Buttons
+**Learning:** Reusable components like `AddButton` that render icon-only buttons need built-in support for `aria-label` to ensure accessibility across different contexts.
+**Action:** Add optional `ariaLabel` props to all icon-only button components with safe defaults.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 # production
 **/build/
+**/dist/
+**/dev-dist/
 
 # misc
 .DS_Store
@@ -22,6 +24,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.log
 
 **/pgdata/
 **/pgdata_*/

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -12,6 +12,7 @@ export const AddButton = (props: {
   node_id: types.TNodeId;
   prefix?: undefined | string;
   id?: string;
+  ariaLabel?: string;
 }) => {
   const dispatch = useDispatch();
   const session = React.use(states.session_key_context);
@@ -29,6 +30,7 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label={props.ariaLabel ?? "Add new item"}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 What: Added optional `ariaLabel` prop to `AddButton` component and applied it to the button element with a default value of "Add new item".
🎯 Why: The `AddButton` component renders an icon-only button which is inaccessible to screen reader users without an explicit label. This change ensures a default label is always present and allows overriding it for specific contexts.
♿ Accessibility: Screen readers will now announce "Add new item" (or the provided label) instead of ignoring the button or reading the icon code.

---
*PR created automatically by Jules for task [7322443775389628076](https://jules.google.com/task/7322443775389628076) started by @kshramt*