### PR TITLE
🎨 Palette: Add accessible labels to Add buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+
+# Build artifacts and logs
+**/dev-dist/
+*.log

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -12,6 +12,7 @@ export const AddButton = (props: {
   node_id: types.TNodeId;
   prefix?: undefined | string;
   id?: string;
+  ariaLabel?: string;
 }) => {
   const dispatch = useDispatch();
   const session = React.use(states.session_key_context);
@@ -25,12 +26,15 @@ export const AddButton = (props: {
     );
     dispatch(actions.focusFirstChildTextAreaActionOf(props.node_id, prefix));
   }, [props.node_id, dispatch, show_mobile, prefix]);
+  const label = props.ariaLabel || "Add new item";
   return (
     <button
       className="btn-icon"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label={label}
+      title={label}
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/Calendar/AddButton.tsx
+++ b/client/src/Calendar/AddButton.tsx
@@ -18,8 +18,14 @@ const AddButton = (props: { timeId: string }) => {
       }),
     );
   }, [dispatch, props.timeId, nodeIds]);
+  const label = "Add selected nodes to this time slot";
   return (
-    <button className="btn-icon" onClick={handleClick}>
+    <button
+      className="btn-icon"
+      onClick={handleClick}
+      aria-label={label}
+      title={label}
+    >
       {consts.ADD_MARK}
     </button>
   );


### PR DESCRIPTION
This PR adds `aria-label` and `title` attributes to `AddButton` components in the client application to improve accessibility and usability.

### Changes
- **`client/src/AddButton.tsx`**: Added an optional `ariaLabel` prop. The button now renders with an `aria-label` (and `title` for tooltip) defaulting to "Add new item".
- **`client/src/Calendar/AddButton.tsx`**: Added hardcoded `aria-label` and `title` with "Add selected nodes to this time slot".
- **`.gitignore`**: Added `**/dev-dist/` and `*.log` to ignore build artifacts and logs.

### Verification
- Ran `tsc`, `eslint`, and `prettier` checks successfully.
- Verified frontend build and startup using a Playwright script (screenshots verified login page renders).
- Manual verification of code changes to ensure correct prop propagation.

---
*PR created automatically by Jules for task [8281700605263685477](https://jules.google.com/task/8281700605263685477) started by @kshramt*