### PR TITLE
⚡ Bolt: Optimize QueueEntry re-renders

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// Wrapped in React.memo to prevent unnecessary re-renders when the parent list re-renders.
+// This is critical for performance in virtualized lists (react-virtuoso).
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
Wrapped `QueueEntry` component in `React.memo` to prevent unnecessary re-renders in virtualized lists.

---
*PR created automatically by Jules for task [15280161839130634303](https://jules.google.com/task/15280161839130634303) started by @kshramt*