### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -378,6 +378,23 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::HeaderName::from_static("x-content-type-options"),
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::HeaderName::from_static("x-frame-options"),
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::HeaderName::from_static("x-xss-protection"),
+            axum::http::HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -388,9 +405,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +415,28 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, Router};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = Router::new();
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+
+        assert_eq!(headers.get("x-content-type-options").unwrap(), "nosniff");
+        assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(headers.get("x-xss-protection").unwrap(), "1; mode=block");
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add security headers
        
**Vulnerability:** Missing standard HTTP security headers that protect against clickjacking (X-Frame-Options), MIME-sniffing (X-Content-Type-Options), and XSS (X-XSS-Protection).
**Impact:** 
- Without `X-Frame-Options`, the site could be embedded in an iframe for clickjacking attacks.
- Without `X-Content-Type-Options`, browsers might execute non-script files as scripts.
- Without `X-XSS-Protection`, older browsers lack a layer of defense against XSS.
**Fix:** Added `tower_http::set_header::SetResponseHeaderLayer` middleware to `api_v2/src/main.rs` to enforce these headers.
**Verification:** Added a new unit test `test_security_headers` in `api_v2/src/main.rs` that verifies the headers are present on a dummy request. Verified via `cargo test`.

---
*PR created automatically by Jules for task [13438698084263334212](https://jules.google.com/task/13438698084263334212) started by @kshramt*