### PR TITLE
⚡ Bolt: Add React.memo to QueueEntry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 # production
 **/build/
+**/dist/
+**/dev-dist/
 
 # misc
 .DS_Store
@@ -22,6 +24,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.log
 
 **/pgdata/
 **/pgdata_*/

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,9 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+// Optimized: Wrapped in React.memo to prevent unnecessary re-renders in virtualized lists.
+// This is critical for scroll performance in react-virtuoso.
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +31,7 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -19,19 +19,18 @@ import TopButton from "./TopButton";
 
 // Optimized: Wrapped in React.memo to prevent unnecessary re-renders in virtualized lists.
 // This is critical for scroll performance in react-virtuoso.
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
Wrapped `QueueEntry` in `React.memo` to improve virtualized list performance. Updated `.gitignore` to exclude build artifacts.

---
*PR created automatically by Jules for task [13778416222065415798](https://jules.google.com/task/13778416222065415798) started by @kshramt*