### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - Missing Security Headers Gap
+**Vulnerability:** API responses lacked standard security headers (X-Frame-Options, X-Content-Type-Options, X-XSS-Protection) despite external documentation/memory suggesting they were present.
+**Learning:** Reliance on memory or outdated documentation for security posture is dangerous. The 'missing' headers exposed the app to potential clickjacking and MIME sniffing attacks.
+**Prevention:** Verify security configurations directly in the code (e.g., via automated tests) rather than assuming they exist based on prior knowledge.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -378,6 +378,23 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::HeaderName::from_static("x-frame-options"),
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::HeaderName::from_static("x-xss-protection"),
+            axum::http::HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -388,9 +405,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +415,32 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, routing::get, Router};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = Router::new().route("/", get(|| async { "hello" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get("X-Content-Type-Options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(response.headers().get("X-Frame-Options").unwrap(), "DENY");
+        assert_eq!(
+            response.headers().get("X-XSS-Protection").unwrap(),
+            "1; mode=block"
+        );
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add security headers

**Vulnerability:** Missing standard HTTP security headers allowed potential clickjacking and MIME sniffing.
**Impact:** Medium. While the API is primarily JSON, these headers provide defense-in-depth protection against various web-based attacks if the API is accessed in a browser context.
**Fix:** Applied `tower_http` SetResponseHeaderLayer to add `X-Frame-Options`, `X-Content-Type-Options`, and `X-XSS-Protection`.
**Verification:** Added unit test `test_security_headers` in `api_v2/src/main.rs` which verifies the headers are set on response. Verified with `cargo test`.

---
*PR created automatically by Jules for task [16720226848819898160](https://jules.google.com/task/16720226848819898160) started by @kshramt*