### PR TITLE
🎨 Palette: Improve AddButton accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Icon-Only Button Accessibility
+**Learning:** Icon-only buttons using Material Icon ligatures (e.g. `<span ...>add</span>`) are invisible to screen readers without explicit `aria-label`s. The text content "add" is not sufficient as a label for many assistive technologies when rendered as a ligature.
+**Action:** Always add `aria-label` and `title` to icon-only buttons, especially when using font ligatures for icons.

--- a/client/dev-dist/registerSW.js
+++ b/client/dev-dist/registerSW.js
@@ -1,0 +1,1 @@
+if('serviceWorker' in navigator) navigator.serviceWorker.register('/dev-sw.js?dev-sw', { scope: '/', type: 'classic' })

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -12,6 +12,7 @@ export const AddButton = (props: {
   node_id: types.TNodeId;
   prefix?: undefined | string;
   id?: string;
+  ariaLabel?: string;
 }) => {
   const dispatch = useDispatch();
   const session = React.use(states.session_key_context);
@@ -31,6 +32,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label={props.ariaLabel || "Add new item"}
+      title={props.ariaLabel || "Add new item"}
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -41,7 +41,13 @@ export const EntryButtons = (props: {
       {is_root || !is_todo || <MoveUpButton node_id={props.node_id} />}
       {is_root || !is_todo || <MoveDownButton node_id={props.node_id} />}
       {/* <DeleteButton node_id={props.node_id} /> */}
-      {is_todo && <AddButton node_id={props.node_id} prefix={props.prefix} />}
+      {is_todo && (
+        <AddButton
+          node_id={props.node_id}
+          prefix={props.prefix}
+          ariaLabel="Add sub-task"
+        />
+      )}
       <ShowDetailsButton node_id={props.node_id} />
       {props.jumpButton}
     </div>

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -427,7 +427,11 @@ const Menu = (props: {
       >
         {consts.STOP_MARK}
       </button>
-      <AddButton node_id={root} id="add-root-button" />
+      <AddButton
+        node_id={root}
+        id="add-root-button"
+        ariaLabel="Add new item to root"
+      />
       <button
         className="btn-icon"
         aria-label="Undo."
@@ -1135,7 +1139,7 @@ const MobileMenu = (props: {
       >
         {consts.STOP_MARK}
       </button>
-      <AddButton node_id={root} />
+      <AddButton node_id={root} ariaLabel="Add new item to root" />
       <button
         className="btn-icon"
         aria-label="Undo."
@@ -1329,7 +1333,9 @@ const MobileEntryButtons = (props: { node_id: types.TNodeId }) => {
         {is_root || status !== "todo" || <TopButton node_id={props.node_id} />}
         {/* <DeleteButton node_id={props.node_id} /> */}
         <CopyNodeIdButton node_id={props.node_id} />
-        {status === "todo" && <AddButton node_id={props.node_id} />}
+        {status === "todo" && (
+          <AddButton node_id={props.node_id} ariaLabel="Add sub-task" />
+        )}
         <ShowDetailsButton node_id={props.node_id} />
         <TotalTime node_id={props.node_id} />
         {is_root || <LastRange node_id={props.node_id} />}


### PR DESCRIPTION
💡 What: Added an optional ariaLabel prop to the AddButton component and updated usages to provide descriptive labels.
🎯 Why: Icon-only buttons relying on Material Icon ligatures are inaccessible to screen readers without explicit labels.
♿ Accessibility: Added aria-label and title attributes to AddButton for screen reader support and mouse tooltips.

---
*PR created automatically by Jules for task [8728997718771382591](https://jules.google.com/task/8728997718771382591) started by @kshramt*