### PR TITLE
🛡️ Sentinel: [HIGH] Add security headers (X-Frame, X-XSS, X-Content-Type)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-10-25 - Centralized Middleware for Security Headers
+**Vulnerability:** Missing default security headers (X-Frame-Options, etc.) across the application.
+**Learning:** Axum 0.7 + Tower requires manual composition of header layers. `axum::http` lacks constants for some legacy security headers.
+**Prevention:** Established `apply_middleware` pattern in `main.rs` to enforce security headers globally and enable isolated testing of middleware stack.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -445,7 +445,9 @@ mod tests {
 
         let headers = response.headers();
         assert_eq!(
-            headers.get(axum::http::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            headers
+                .get(axum::http::header::X_CONTENT_TYPE_OPTIONS)
+                .unwrap(),
             "nosniff"
         );
         assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,9 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{
+        header::{HeaderName, HeaderValue},
+        request::Parts,
+    },
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -388,9 +391,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +401,54 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-frame-options"),
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-xss-protection"),
+            HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::get,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = Router::new().route("/", get(|| async { "Hello, world!" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let headers = response.headers();
+        assert_eq!(
+            headers.get(axum::http::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(headers.get("x-xss-protection").unwrap(), "1; mode=block");
+    }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing standard security headers (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection) which are crucial for defense-in-depth against clickjacking and MIME sniffing.
🎯 Impact: Reduced protection against common web vulnerabilities.
🔧 Fix:
- Refactored `api_v2/src/main.rs` to extract `apply_middleware` function.
- Added `tower_http::set_header::SetResponseHeaderLayer` for:
    - `X-Content-Type-Options: nosniff`
    - `X-Frame-Options: DENY`
    - `X-XSS-Protection: 1; mode=block`
✅ Verification: Added a unit test `test_security_headers` in `main.rs` that verifies these headers are present on responses.

---
*PR created automatically by Jules for task [9784940109102086929](https://jules.google.com/task/9784940109102086929) started by @kshramt*