### PR TITLE
⚡ Bolt: Memoize QueueEntry to reduce re-renders

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,18 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` component in `React.memo`.
🎯 Why: `QueueEntry` is used as an item component in `react-virtuoso` lists. Without memoization, it may re-render unnecessarily when the parent list component re-renders or when other items update, leading to performance degradation in large lists.
📊 Impact: Reduces re-renders of list items, improving scrolling performance and responsiveness.
🔬 Measurement: Verified by manual inspection and ensuring build/lint checks pass. Ideally, this would be verified with a React Profiler recording showing fewer commits for QueueEntry components during interactions that trigger parent updates.

---
*PR created automatically by Jules for task [17734732145435364613](https://jules.google.com/task/17734732145435364613) started by @kshramt*