### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to api_v2

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Missing Security Headers in Backend
+**Vulnerability:** The `api_v2` backend lacked standard security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`), increasing exposure to XSS, clickjacking, and MIME sniffing attacks.
+**Learning:** `axum` and `tower-http` do not apply these headers by default. Testing these headers effectively requires isolating the middleware application logic (e.g., `apply_middleware`) from the `main` function to enable unit testing without external dependencies like a database.
+**Prevention:** Always verify security headers using automated tests. Use a dedicated `apply_middleware` function to allow unit testing of the middleware stack.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{header, request::Parts, HeaderValue},
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -13,6 +13,7 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
@@ -388,9 +389,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +399,60 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_XSS_PROTECTION,
+            HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::get,
+    };
+    use tower::ServiceExt; // for oneshot
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = axum::Router::new().route("/", get(|| async { "hello" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::X_CONTENT_TYPE_OPTIONS)
+                .unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            response.headers().get(header::X_FRAME_OPTIONS).unwrap(),
+            "DENY"
+        );
+        assert_eq!(
+            response.headers().get(header::X_XSS_PROTECTION).unwrap(),
+            "1; mode=block"
+        );
+    }
 }


### PR DESCRIPTION
This PR enhances the security of the `api_v2` backend by adding essential HTTP security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`). These headers help protect against XSS, clickjacking, and MIME sniffing attacks.

Changes:
- Refactored `api_v2/src/main.rs` to extract middleware application into a `apply_middleware` function.
- Added `tower_http::set_header::SetResponseHeaderLayer` to apply the security headers.
- Added a unit test `test_security_headers` to verify that the headers are correctly set on responses.
- Created `.jules/sentinel.md` to document the security improvement.

Verified with `cargo test -p api_v2`, `cargo check`, `cargo fmt`, and `cargo clippy`.

---
*PR created automatically by Jules for task [16680408709824654688](https://jules.google.com/task/16680408709824654688) started by @kshramt*