### PR TITLE
⚡ Bolt: Wrap QueueEntry in React.memo for Virtualized List Performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+**/dist/
+**/dev-dist/
+*.log

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,18 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped the `QueueEntry` component in `React.memo` in `client/src/QueueEntry.tsx`.
🎯 Why: `QueueEntry` is used as the `itemContent` for `react-virtuoso` in `client/src/components.tsx`. Without `React.memo`, the component re-renders every time the virtualized list updates, even if the item props (`node_id`, `index`) haven't changed. This is a critical performance optimization for large lists.
📊 Impact: Reduces unnecessary re-renders of list items during scrolling and list updates.
🔬 Measurement: Verified with `pnpm build` and `pnpm lint`. The optimization relies on React's standard behavior and `react-virtuoso` documentation recommendations.
Also updated `.gitignore` to exclude `dist` directories.

---
*PR created automatically by Jules for task [10845692130437401031](https://jules.google.com/task/10845692130437401031) started by @kshramt*