### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # production
 **/build/
+**/dist/
 
 # misc
 .DS_Store

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-08 - Icon-Only Buttons Missing Accessible Labels
+**Learning:** The application extensively uses icon-only buttons (via `material-icons`) without `aria-label` or `title` attributes. This makes the interface inaccessible to screen reader users and ambiguous for sighted users who may not recognize the icons.
+**Action:** When creating or modifying icon-only buttons, always include `aria-label` (for screen readers) and `title` (for tooltips) to ensure clarity and accessibility.

--- a/client/dev-dist/registerSW.js
+++ b/client/dev-dist/registerSW.js
@@ -1,0 +1,1 @@
+if('serviceWorker' in navigator) navigator.serviceWorker.register('/dev-sw.js?dev-sw', { scope: '/', type: 'classic' })

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -111,6 +111,8 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Show details"
+      title="Show details"
     >
       {consts.DETAIL_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start task"
+      title="Start task"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -110,6 +110,8 @@ const MobileNodeFilterQueryInput = () => {
         className="icon-icon"
         onClick={clear_input}
         onDoubleClick={prevent_propagation}
+        aria-label="Clear filter"
+        title="Clear filter"
       >
         {consts.DELETE_MARK}
       </button>
@@ -167,6 +169,8 @@ const NodeFilterQueryInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear filter"
+          title="Clear filter"
         >
           {consts.DELETE_MARK}
         </button>
@@ -315,6 +319,8 @@ const NodeIdsInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear IDs"
+          title="Clear IDs"
         >
           {consts.DELETE_MARK}
         </button>
@@ -328,6 +334,8 @@ const SBTTB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[60%] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to top"
+      title="Scroll to top"
     >
       {SCROLL_BACK_TO_TOP_MARK}
     </button>
@@ -339,6 +347,8 @@ const SBTBB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[calc(60%+4rem)] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to bottom"
+      title="Scroll to bottom"
     >
       {SCROLL_BACK_TO_BOTTOM_MARK}
     </button>
@@ -362,6 +372,8 @@ export const ToggleShowMobileButton = () => {
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
+      aria-label="Toggle mobile view"
+      title="Toggle mobile view"
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}
     </button>
@@ -424,6 +436,8 @@ const Menu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all tasks"
+        title="Stop all tasks"
       >
         {consts.STOP_MARK}
       </button>
@@ -578,7 +592,12 @@ const Timeline = () => {
   return (
     <>
       {decade_nodes}
-      <button className="btn-icon" onClick={increment_count}>
+      <button
+        className="btn-icon"
+        onClick={increment_count}
+        aria-label="Add time period"
+        title="Add time period"
+      >
         {consts.ADD_MARK}
       </button>
     </>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to multiple icon-only buttons in `client/src/components.tsx`, `client/src/StartButton/index.tsx`, and `client/src/ShowDetailsButton/index.tsx`.

🎯 Why: These buttons relied solely on icons (Material Icons), making them inaccessible to screen readers and potentially confusing for users without tooltips. This improves accessibility and usability.

♿ Accessibility: Screen readers will now announce the purpose of these buttons (e.g., 'Stop all tasks', 'Scroll to top', 'Start task'). Sighted users will see tooltips on hover.

Note:
- Verified that the application builds and lints correctly.
- Frontend verification was limited to checking the login screen as the backend/database is not available for full UI rendering.
- Added `.jules/palette.md` to document the lack of accessible labels pattern.
- Added `**/dist/` to `.gitignore` to prevent build artifacts from being committed.

---
*PR created automatically by Jules for task [13602302146881226194](https://jules.google.com/task/13602302146881226194) started by @kshramt*