### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to API v2

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,7 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
     http::request::Parts,
+    http::HeaderValue,
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -13,6 +14,7 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
@@ -378,6 +380,23 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_XSS_PROTECTION,
+            HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -388,9 +407,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +417,40 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = axum::Router::new().route("/", axum::routing::get(|| async { "ok" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+
+        assert_eq!(
+            headers
+                .get(axum::http::header::X_CONTENT_TYPE_OPTIONS)
+                .unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            headers.get(axum::http::header::X_FRAME_OPTIONS).unwrap(),
+            "DENY"
+        );
+        assert_eq!(
+            headers.get(axum::http::header::X_XSS_PROTECTION).unwrap(),
+            "1; mode=block"
+        );
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add security headers to API v2

**Severity:** MEDIUM

**Vulnerability:** Missing HTTP security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`) could allow attackers to perform MIME sniffing, clickjacking, or exploit XSS vulnerabilities.

**Impact:** 
- **MIME Sniffing:** Browsers might interpret files as a different MIME type than declared, potentially executing malicious scripts.
- **Clickjacking:** Attackers could embed the application in an iframe to trick users into clicking hidden buttons.
- **XSS:** Lack of XSS protection header might disable browser-side XSS filters (though modern browsers are deprecating this, it's still good defense-in-depth).

**Fix:**
Implemented a middleware layer in `api_v2/src/main.rs` that adds the following headers to all responses:
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `X-XSS-Protection: 1; mode=block`

**Verification:**
Added a unit test `test_security_headers` in `api_v2/src/main.rs` that:
1. Creates a dummy Axum router.
2. Applies the middleware.
3. Sends a request and asserts that the headers are present in the response with correct values.

Ran `cargo test` in `api_v2` and it passed.

---
*PR created automatically by Jules for task [15316079641875157488](https://jules.google.com/task/15316079641875157488) started by @kshramt*