### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -105,11 +105,13 @@ const MobileNodeFilterQueryInput = () => {
         value={nodeFilterQuery}
         onChange={handle_change}
         className="h-[2em] border-none w-[8em]"
+        aria-label="Filter nodes"
       />
       <button
         className="icon-icon"
         onClick={clear_input}
         onDoubleClick={prevent_propagation}
+        aria-label="Clear filter"
       >
         {consts.DELETE_MARK}
       </button>
@@ -162,11 +164,13 @@ const NodeFilterQueryInput = () => {
           onKeyDown={onKeyDown}
           className="h-[2em] border-none"
           ref={ref}
+          aria-label="Filter nodes"
         />
         <button
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear filter"
         >
           {consts.DELETE_MARK}
         </button>
@@ -310,11 +314,13 @@ const NodeIdsInput = () => {
           value={nodeIds}
           onChange={handle_change}
           className="h-[2em] border-none"
+          aria-label="Filter by node IDs"
         />
         <button
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear node IDs filter"
         >
           {consts.DELETE_MARK}
         </button>
@@ -328,6 +334,7 @@ const SBTTB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[60%] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to top"
     >
       {SCROLL_BACK_TO_TOP_MARK}
     </button>
@@ -339,6 +346,7 @@ const SBTBB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[calc(60%+4rem)] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to bottom"
     >
       {SCROLL_BACK_TO_BOTTOM_MARK}
     </button>
@@ -362,6 +370,9 @@ export const ToggleShowMobileButton = () => {
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
+      aria-label={
+        show_mobile ? "Switch to desktop view" : "Switch to mobile view"
+      }
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}
     </button>
@@ -424,6 +435,7 @@ const Menu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all tasks"
       >
         {consts.STOP_MARK}
       </button>


### PR DESCRIPTION
This PR improves accessibility by adding descriptive ARIA labels to several icon-only buttons and inputs in the main UI components. This ensures that screen reader users can understand the purpose of these controls, particularly for filtering and navigation.

**Key Changes:**
- **Filtering Inputs:** Added "Filter nodes" and "Filter by node IDs" labels.
- **Clear Buttons:** Added specific "Clear filter" labels to the 'X' buttons associated with inputs.
- **Scroll Buttons:** Added "Scroll to top" and "Scroll to bottom" labels.
- **Mobile Toggle:** Added a dynamic label that announces "Switch to desktop view" or "Switch to mobile view" based on the current state.
- **Stop Button:** Added "Stop all tasks" label.

**Verification:**
- Verified that `pnpm build`, `pnpm lint`, and `pnpm format` pass.
- Code review confirmed the changes are correct and safe.

---
*PR created automatically by Jules for task [11417664266279461423](https://jules.google.com/task/11417664266279461423) started by @kshramt*