### PR TITLE
Add security headers to api_v2

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - [Adding Security Headers to Axum API]
+**Vulnerability:** Missing standard security headers (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection) in Axum API.
+**Learning:** `tower_http::set_header::SetResponseHeaderLayer` is the standard way to add these headers in Axum/Tower applications. Tests can be written using `oneshot` on the router without starting the full server.
+**Prevention:** Always include `tower-http` with `set-header` feature and apply these headers as middleware in the application setup.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,7 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
     http::request::Parts,
+    http::{header, HeaderValue},
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -13,6 +14,7 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
@@ -378,6 +380,26 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        // Prevent MIME sniffing
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        // Prevent clickjacking
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        // Enable XSS protection in older browsers
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_XSS_PROTECTION,
+            HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -388,9 +410,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +420,34 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = axum::Router::new().route("/", axum::routing::get(|| async { "hello" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(headers.get(header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            headers.get(header::X_XSS_PROTECTION).unwrap(),
+            "1; mode=block"
+        );
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel: [Security Enhancement] Add standard security headers

🚨 Severity: MEDIUM (Enhancement)
💡 Vulnerability: Missing standard HTTP security headers which help prevent common attacks like MIME sniffing, clickjacking, and XSS.
🎯 Impact: Without these headers, the application is more susceptible to these classes of attacks.
🔧 Fix: Added `tower_http::set_header::SetResponseHeaderLayer` middleware to `api_v2` to set:
    - `X-Content-Type-Options: nosniff`
    - `X-Frame-Options: DENY`
    - `X-XSS-Protection: 1; mode=block`
✅ Verification: Added a new test `tests::test_security_headers` in `api_v2/src/main.rs` that verifies these headers are present in responses. Verified with `cargo test`.

---
*PR created automatically by Jules for task [5998106502502043317](https://jules.google.com/task/5998106502502043317) started by @kshramt*