### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-02-12 - Icon-Only Button Accessibility Pattern
+**Learning:** Icon-only buttons (using `className="btn-icon"` or `className="icon-icon"`) are frequently used without `aria-label` or `title` attributes, making them inaccessible to screen readers. Specifically, components like `SBTTB`, `SBTBB`, and filter inputs rely solely on visual icons.
+**Action:** When creating or modifying icon-only buttons, always enforce the inclusion of `aria-label` (for screen readers) and `title` (for tooltips). Additionally, standardize on `btn-icon` class instead of inconsistent `icon-icon`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN cargo install sqlx-cli@0.8.2
 FROM build_essential_base AS base_rust
 COPY --link --from=rust_downloader /usr/local/cargo /usr/local/cargo
 COPY --link --from=rust_downloader /usr/local/rustup /usr/local/rustup
-ENV PATH "/usr/local/cargo/bin:/usr/local/rustup/bin:${PATH}"
+ENV PATH="/usr/local/cargo/bin:/usr/local/rustup/bin:${PATH}"
 ENV RUSTUP_HOME="/usr/local/rustup"
 ENV CARGO_HOME="/usr/local/cargo"
 
@@ -180,8 +180,8 @@ ENV RUSTUP_HOME="/usr/local/rustup"
 ENV CARGO_HOME="/home/${devcontainer_user:?}/.cargo"
 
 FROM ubuntu_base AS base_py
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
 WORKDIR /app
 
 FROM nginx:1.29.3-alpine AS base_nginx
@@ -267,7 +267,7 @@ FROM base_postgres AS prod_postgres
 
 FROM debian:13.2-slim AS prod_postgres_migration
 ARG SOURCE_DATE_EPOCH
-ENV SOURCE_DATE_EPOCH ${SOURCE_DATE_EPOCH:-0}
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-0}
 COPY --link --from=base_dbmate /usr/local/bin/dbmate /usr/local/bin/dbmate
 COPY --link db/scripts/migrate.sh /app/scripts/migrate.sh
 COPY --link db/migrations /app/db/migrations
@@ -309,7 +309,7 @@ RUN cargo build --release
 
 FROM gcr.io/distroless/cc-debian12:nonroot AS prod_api_v2
 ARG SOURCE_DATE_EPOCH
-ENV SOURCE_DATE_EPOCH ${SOURCE_DATE_EPOCH:-0}
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-0}
 COPY --link --from=base_rust_builder /app/target/release/api_v2 /work/api_v2
 WORKDIR /work
 ENTRYPOINT ["./api_v2"]

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -372,7 +372,9 @@ export const ToggleShowMobileButton = () => {
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
-      aria-label={show_mobile ? "Switch to desktop view" : "Switch to mobile view"}
+      aria-label={
+        show_mobile ? "Switch to desktop view" : "Switch to mobile view"
+      }
       title={show_mobile ? "Switch to desktop view" : "Switch to mobile view"}
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -107,9 +107,11 @@ const MobileNodeFilterQueryInput = () => {
         className="h-[2em] border-none w-[8em]"
       />
       <button
-        className="icon-icon"
+        className="btn-icon"
         onClick={clear_input}
         onDoubleClick={prevent_propagation}
+        aria-label="Clear filter"
+        title="Clear filter"
       >
         {consts.DELETE_MARK}
       </button>
@@ -167,6 +169,8 @@ const NodeFilterQueryInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear filter"
+          title="Clear filter"
         >
           {consts.DELETE_MARK}
         </button>
@@ -315,6 +319,8 @@ const NodeIdsInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear selection"
+          title="Clear selection"
         >
           {consts.DELETE_MARK}
         </button>
@@ -328,6 +334,8 @@ const SBTTB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[60%] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll back to top"
+      title="Scroll back to top"
     >
       {SCROLL_BACK_TO_TOP_MARK}
     </button>
@@ -339,6 +347,8 @@ const SBTBB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[calc(60%+4rem)] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll back to bottom"
+      title="Scroll back to bottom"
     >
       {SCROLL_BACK_TO_BOTTOM_MARK}
     </button>
@@ -362,6 +372,8 @@ export const ToggleShowMobileButton = () => {
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
+      aria-label={show_mobile ? "Switch to desktop view" : "Switch to mobile view"}
+      title={show_mobile ? "Switch to desktop view" : "Switch to mobile view"}
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}
     </button>


### PR DESCRIPTION
This PR improves the accessibility of icon-only buttons in the `client` application.

**Changes:**
- Added `aria-label` and `title` attributes to `MobileNodeFilterQueryInput`, `NodeFilterQueryInput`, `NodeIdsInput`, `SBTTB` (Scroll Back To Top Button), `SBTBB` (Scroll Back To Bottom Button), and `ToggleShowMobileButton`.
- Standardized the CSS class for `MobileNodeFilterQueryInput` to `btn-icon`, replacing the undefined/inconsistent `icon-icon` class.
- Added a journal entry in `.jules/palette.md` regarding the importance of ARIA labels for icon-only buttons.

**Verification:**
- Verified `pnpm build` passes.
- Verified linting passes.
- Manually inspected code to ensure correct attribute application.
- Note: Existing tests fail due to an unrelated `loupe` dependency issue, but these changes do not introduce new failures.

---
*PR created automatically by Jules for task [10381803108074733734](https://jules.google.com/task/10381803108074733734) started by @kshramt*