### PR TITLE
🛡️ Sentinel: Add security headers to api_v2

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,7 +1,7 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
-    Json, RequestPartsExt,
+    http::{header, request::Parts, HeaderValue},
+    Json, RequestPartsExt, Router,
 };
 use axum_extra::{
     headers::{authorization::Bearer, Authorization},
@@ -13,6 +13,7 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
@@ -378,6 +379,23 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn apply_middleware(app: Router) -> Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_XSS_PROTECTION,
+            HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -388,9 +406,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +416,33 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::get,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = Router::new().route("/", get(|| async { "hello" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let headers = response.headers();
+        assert_eq!(headers[header::X_CONTENT_TYPE_OPTIONS], "nosniff");
+        assert_eq!(headers[header::X_FRAME_OPTIONS], "DENY");
+        assert_eq!(headers[header::X_XSS_PROTECTION], "1; mode=block");
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel: [Security Enhancement] Add security headers to backend responses

**Security Improvement:**
Added standard security headers to all `api_v2` responses to mitigate common web vulnerabilities:
- `X-Content-Type-Options: nosniff`: Prevents MIME-sniffing attacks.
- `X-Frame-Options: DENY`: Prevents Clickjacking attacks by disallowing the site to be embedded in an iframe.
- `X-XSS-Protection: 1; mode=block`: Enables the browser's XSS filter (defense in depth for older browsers).

**Implementation:**
- Used `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs`.
- Extracted middleware configuration into `apply_middleware` function to allow unit testing without starting the full server.
- Added a `test_security_headers` unit test in `api_v2/src/main.rs` to verify the presence and values of these headers.

**Verification:**
- `cargo test` passed.
- `cargo check` passed.
- `cargo fmt` applied.

---
*PR created automatically by Jules for task [10639943781019455373](https://jules.google.com/task/10639943781019455373) started by @kshramt*