### PR TITLE
⚡ Bolt: Memoize QueueEntry component

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,19 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// Memoize to prevent unnecessary re-renders in virtualized lists
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` with `React.memo`.
🎯 Why: `QueueEntry` is a list item in a virtualized list (`Virtuoso`). Without memoization, it re-renders whenever the parent (`VirtualizedQueueNodes`) re-renders, even if the item's `node_id` and `index` haven't changed. This is a recommended optimization for `react-virtuoso`.
📊 Impact: Reduces unnecessary re-renders of queue items.
🔬 Measurement: Verified via static analysis (lint/tsc) and visual inspection (screenshot) to ensure no regression in rendering.

---
*PR created automatically by Jules for task [9018524638527405793](https://jules.google.com/task/9018524638527405793) started by @kshramt*