### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - Reusable Security Headers Pattern in Axum
+**Vulnerability:** Missing default security headers (X-Frame-Options, X-Content-Type-Options, X-XSS-Protection) in api_v2.
+**Learning:** Axum requires explicit middleware for security headers. `tower-http` provides `SetResponseHeaderLayer` for this. Grouping middleware in `apply_middleware` allows for isolated testing of security configuration.
+**Prevention:** Use the `apply_middleware` function pattern in `api_v2/src/main.rs` to enforce security headers and verify them with `tower::ServiceExt::oneshot` tests.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,12 +1,13 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{request::Parts, HeaderValue},
     Json, RequestPartsExt,
 };
 use axum_extra::{
     headers::{authorization::Bearer, Authorization},
     TypedHeader,
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use base64::Engine;
 use serde_json::json;
 use std::{
@@ -378,6 +379,23 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_XSS_PROTECTION,
+            HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -388,9 +406,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +416,44 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::get,
+        Router,
+    };
+    use tower::ServiceExt; // for `oneshot`
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = Router::new().route("/", get(|| async { "Hello, World!" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get("x-content-type-options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            headers.get("x-frame-options").unwrap(),
+            "DENY"
+        );
+        assert_eq!(
+            headers.get("x-xss-protection").unwrap(),
+            "1; mode=block"
+        );
+    }
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -7,13 +7,13 @@ use axum_extra::{
     headers::{authorization::Bearer, Authorization},
     TypedHeader,
 };
-use tower_http::set_header::SetResponseHeaderLayer;
 use base64::Engine;
 use serde_json::json;
 use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
@@ -443,17 +443,8 @@ mod tests {
 
         let headers = response.headers();
 
-        assert_eq!(
-            headers.get("x-content-type-options").unwrap(),
-            "nosniff"
-        );
-        assert_eq!(
-            headers.get("x-frame-options").unwrap(),
-            "DENY"
-        );
-        assert_eq!(
-            headers.get("x-xss-protection").unwrap(),
-            "1; mode=block"
-        );
+        assert_eq!(headers.get("x-content-type-options").unwrap(), "nosniff");
+        assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(headers.get("x-xss-protection").unwrap(), "1; mode=block");
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Add security headers to API

**Goal:** Improve security of the `api_v2` backend by adding standard security headers to all responses.

**Changes:**
- Refactored `api_v2/src/main.rs` to extract middleware application into a new `apply_middleware` function.
- Added `tower_http::set_header::SetResponseHeaderLayer` to `apply_middleware` to set the following headers:
    - `X-Content-Type-Options: nosniff`: Prevents MIME-sniffing.
    - `X-Frame-Options: DENY`: Prevents the API from being embedded in frames (Clickjacking protection).
    - `X-XSS-Protection: 1; mode=block`: Enables browser XSS filtering (legacy but good defense in depth).
- Added a unit test `test_security_headers` in `api_v2/src/main.rs` to verify the presence of these headers.
- Created `.jules/sentinel.md` to document the reusable security pattern.

**Verification:**
- Ran `cargo test` in `api_v2` which passed, confirming the headers are present and the application builds correctly.
- Client tests are known to be broken due to an unrelated `loupe` issue, but backend changes are isolated.

---
*PR created automatically by Jules for task [9347835472389008450](https://jules.google.com/task/9347835472389008450) started by @kshramt*