### PR TITLE
feat: improve CopyNodeIdButton accessibility and ignore dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+**/dist/

--- a/client/dev-dist/registerSW.js
+++ b/client/dev-dist/registerSW.js
@@ -1,0 +1,1 @@
+if('serviceWorker' in navigator) navigator.serviceWorker.register('/dev-sw.js?dev-sw', { scope: '/', type: 'classic' })

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -25,6 +25,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Copy Node ID"
+      title="Copy Node ID (Ctrl/Meta+Click to append)"
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>


### PR DESCRIPTION
Improved accessibility and discoverability of `CopyNodeIdButton` by adding an `aria-label` and a tooltip explaining the hidden append functionality. Also updated `.gitignore` to exclude `dist` folders.

---
*PR created automatically by Jules for task [10877566636686256228](https://jules.google.com/task/10877566636686256228) started by @kshramt*