### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - Axum Security Headers Pattern
+**Vulnerability:** Default Axum setup lacks standard security headers like `X-Frame-Options` and `X-Content-Type-Options`.
+**Learning:** `axum` (v0.7) and `tower-http` (v0.6) separate middleware concerns. Headers must be explicitly added. The `apply_middleware` pattern allows testing middleware isolation without a full app state.
+**Prevention:** Use `tower_http::set_header::SetResponseHeaderLayer` in a dedicated middleware function and unit test it using `oneshot`.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{header, request::Parts},
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -388,9 +388,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +398,59 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::X_XSS_PROTECTION,
+            header::HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, routing::get};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = axum::Router::new().route("/", get(|| async { "Hello, world!" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get(header::X_CONTENT_TYPE_OPTIONS),
+            Some(&header::HeaderValue::from_static("nosniff"))
+        );
+        assert_eq!(
+            headers.get(header::X_FRAME_OPTIONS),
+            Some(&header::HeaderValue::from_static("DENY"))
+        );
+        assert_eq!(
+            headers.get(header::X_XSS_PROTECTION),
+            Some(&header::HeaderValue::from_static("1; mode=block"))
+        );
+    }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard security headers (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection)
🎯 Impact: Potential for clickjacking, MIME-sniffing attacks, and reduced XSS protection
🔧 Fix: Added tower_http::set_header::SetResponseHeaderLayer to apply_middleware in api_v2/src/main.rs
✅ Verification: Added unit test in api_v2/src/main.rs verified with cargo test

---
*PR created automatically by Jules for task [17147451208792656633](https://jules.google.com/task/17147451208792656633) started by @kshramt*