### PR TITLE
🎨 Palette: Add accessible labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Accessibility of Icon-Only Buttons
+**Learning:** Icon-only buttons relying on Material Icon ligatures (e.g., `<span ...>vertical_align_top</span>`) are inaccessible to screen readers because the ligature text is often not meaningful or announced correctly.
+**Action:** Always add explicit `aria-label` and `title` attributes to buttons that contain only an icon. Use the `ariaLabel` prop pattern for reusable components like `AddButton`.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -12,6 +12,7 @@ export const AddButton = (props: {
   node_id: types.TNodeId;
   prefix?: undefined | string;
   id?: string;
+  ariaLabel?: string;
 }) => {
   const dispatch = useDispatch();
   const session = React.use(states.session_key_context);
@@ -25,12 +26,15 @@ export const AddButton = (props: {
     );
     dispatch(actions.focusFirstChildTextAreaActionOf(props.node_id, prefix));
   }, [props.node_id, dispatch, show_mobile, prefix]);
+  const label = props.ariaLabel || "Add new item";
   return (
     <button
       className="btn-icon"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label={label}
+      title={label}
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -25,6 +25,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Copy Node ID"
+      title="Copy Node ID (Ctrl+Click to append)"
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -328,6 +328,8 @@ const SBTTB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[60%] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to top"
+      title="Scroll to top"
     >
       {SCROLL_BACK_TO_TOP_MARK}
     </button>
@@ -339,6 +341,8 @@ const SBTBB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[calc(60%+4rem)] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to bottom"
+      title="Scroll to bottom"
     >
       {SCROLL_BACK_TO_BOTTOM_MARK}
     </button>
@@ -357,11 +361,16 @@ export const ToggleShowMobileButton = () => {
     set_show_mobile((v) => !v);
     setShowMobileUpdatedAt(Date.now());
   }, [set_show_mobile, setShowMobileUpdatedAt]);
+  const label = show_mobile
+    ? "Switch to desktop view"
+    : "Switch to mobile view";
   return (
     <button
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
+      aria-label={label}
+      title={label}
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}
     </button>
@@ -424,6 +433,8 @@ const Menu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all tasks"
+        title="Stop all tasks"
       >
         {consts.STOP_MARK}
       </button>


### PR DESCRIPTION
This PR addresses critical accessibility issues where icon-only buttons lacked descriptive labels, making them inaccessible to screen readers. It also enhances usability by adding tooltips that clarify the function of these buttons.

Specifically:
- `AddButton`: Added `ariaLabel` prop to support context-specific labels.
- `SBTTB` / `SBTBB`: Added labels "Scroll to top" and "Scroll to bottom".
- `ToggleShowMobileButton`: Added dynamic labels "Switch to desktop view" / "Switch to mobile view".
- `Menu` Stop Button: Added label "Stop all tasks".
- `CopyNodeIdButton`: Added label "Copy Node ID" and a tooltip explaining the multi-select feature (Ctrl+Click).

Verification:
- Verified code changes with `grep`.
- Verified build and type checking with `pnpm build`.
- Verified linting and formatting.
- Verified application startup (though full UI verification was limited by authentication).

---
*PR created automatically by Jules for task [2923071732956027710](https://jules.google.com/task/2923071732956027710) started by @kshramt*