### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - Axum Security Headers
+**Vulnerability:** Missing default security headers (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection) in Axum v0.7 application.
+**Learning:** Axum and Tower-HTTP do not inject these headers by default. They must be explicitly added via middleware layers like `SetResponseHeaderLayer`.
+**Prevention:** Use `apply_middleware` pattern to enforce these headers on the router.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{request::Parts, HeaderValue},
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -13,6 +13,7 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
@@ -388,9 +389,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = apply_middleware(app);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +399,61 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_XSS_PROTECTION,
+            HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, routing::get};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = axum::Router::new().route("/", get(|| async { "hello" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::X_CONTENT_TYPE_OPTIONS)
+                .unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::X_FRAME_OPTIONS)
+                .unwrap(),
+            "DENY"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::X_XSS_PROTECTION)
+                .unwrap(),
+            "1; mode=block"
+        );
+    }
 }


### PR DESCRIPTION
This PR enhances the security of the `api_v2` application by adding standard HTTP security headers to all responses. This mitigates common web vulnerabilities such as MIME sniffing, clickjacking, and reflected XSS.

Changes:
- Modified `api_v2/src/main.rs` to include `apply_middleware` function.
- Added `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `X-XSS-Protection: 1; mode=block`.
- Added a unit test to ensure headers are correctly set.
- Created `.jules/sentinel.md` to document the finding.

---
*PR created automatically by Jules for task [3897639588667999039](https://jules.google.com/task/3897639588667999039) started by @kshramt*