### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Missing Security Headers in Axum v0.7
+**Vulnerability:** The backend API was missing standard security headers (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection), leaving it vulnerable to MIME sniffing and clickjacking attacks.
+**Learning:** Axum v0.7 does not include default security headers. They must be explicitly added via middleware like `tower_http::set_header::SetResponseHeaderLayer`.
+**Prevention:** Always include a security middleware stack when initializing Axum routers, specifically setting `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `X-XSS-Protection: 1; mode=block`.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{header, request::Parts, HeaderValue},
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -13,6 +13,7 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
@@ -337,6 +338,21 @@ async fn create_client(
     Ok(client_id)
 }
 
+fn apply_middleware(app: axum::Router) -> axum::Router {
+    app.layer(SetResponseHeaderLayer::overriding(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    ))
+    .layer(SetResponseHeaderLayer::overriding(
+        header::X_FRAME_OPTIONS,
+        HeaderValue::from_static("DENY"),
+    ))
+    .layer(SetResponseHeaderLayer::overriding(
+        header::X_XSS_PROTECTION,
+        HeaderValue::from_static("1; mode=block"),
+    ))
+}
+
 #[derive(Debug)]
 struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
@@ -388,6 +404,7 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
+    let app = apply_middleware(app);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
@@ -400,4 +417,40 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::get,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = axum::Router::new().route("/", get(|| async { "Hello, World!" }));
+        let app = apply_middleware(app);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(headers.get(header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            headers.get(header::X_XSS_PROTECTION).unwrap(),
+            "1; mode=block"
+        );
+    }
 }


### PR DESCRIPTION
Adds X-Content-Type-Options, X-Frame-Options, and X-XSS-Protection headers using tower-http middleware to enhance security. Also includes a unit test to verify the headers.

---
*PR created automatically by Jules for task [16701257755827343186](https://jules.google.com/task/16701257755827343186) started by @kshramt*