### PR TITLE
⚡ Bolt: Optimize QueueEntry rendering with React.memo

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// Explicit `React.memo` is required for components rendered by `react-virtuoso`
+// to prevent parent-triggered re-renders.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 **What:** Wrapped `QueueEntry` component in `React.memo`.
🎯 **Why:** To prevent unnecessary re-renders of list items in `react-virtuoso` when the parent component updates or when other items change.
📊 **Impact:** Reduces re-renders significantly during scrolling and list updates, improving frontend performance.
🔬 **Measurement:** Verified with `tsc`, `eslint`, and `prettier`. Functional verification relying on code correctness as unit tests are currently broken due to a dependency issue.


---
*PR created automatically by Jules for task [16600675331553297430](https://jules.google.com/task/16600675331553297430) started by @kshramt*