### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 # production
 **/build/
+**/dist/
+**/dev-dist/
 
 # misc
 .DS_Store

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -107,9 +107,11 @@ const MobileNodeFilterQueryInput = () => {
         className="h-[2em] border-none w-[8em]"
       />
       <button
-        className="icon-icon"
+        className="btn-icon"
         onClick={clear_input}
         onDoubleClick={prevent_propagation}
+        aria-label="Clear search"
+        title="Clear search"
       >
         {consts.DELETE_MARK}
       </button>
@@ -167,6 +169,8 @@ const NodeFilterQueryInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear search"
+          title="Clear search"
         >
           {consts.DELETE_MARK}
         </button>
@@ -315,6 +319,8 @@ const NodeIdsInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear node IDs"
+          title="Clear node IDs"
         >
           {consts.DELETE_MARK}
         </button>
@@ -328,6 +334,8 @@ const SBTTB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[60%] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll back to top"
+      title="Scroll back to top"
     >
       {SCROLL_BACK_TO_TOP_MARK}
     </button>
@@ -339,6 +347,8 @@ const SBTBB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[calc(60%+4rem)] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll back to bottom"
+      title="Scroll back to bottom"
     >
       {SCROLL_BACK_TO_BOTTOM_MARK}
     </button>
@@ -362,6 +372,10 @@ export const ToggleShowMobileButton = () => {
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
+      aria-label={
+        show_mobile ? "Switch to desktop view" : "Switch to mobile view"
+      }
+      title={show_mobile ? "Switch to desktop view" : "Switch to mobile view"}
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}
     </button>
@@ -424,6 +438,8 @@ const Menu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all tasks"
+        title="Stop all tasks"
       >
         {consts.STOP_MARK}
       </button>
@@ -1132,6 +1148,8 @@ const MobileMenu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all tasks"
+        title="Stop all tasks"
       >
         {consts.STOP_MARK}
       </button>


### PR DESCRIPTION
💡 What: Added aria-label and title attributes to icon-only buttons (SBTTB, SBTBB, Search clear, Stop All, Toggle Mobile). Corrected typo icon-icon to btn-icon. Added build artifacts to .gitignore.
🎯 Why: Screen readers announced icon ligatures (e.g., "vertical_align_top") instead of actions. Sighted users lacked tooltips. Build artifacts were polluting the repo.
♿ Accessibility: Added descriptive labels to 7+ interactive elements. Fixed button class for keyboard focus visibility.

---
*PR created automatically by Jules for task [17793733773199770004](https://jules.google.com/task/17793733773199770004) started by @kshramt*