### PR TITLE
Palette: Add accessibility labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Accessibility for Icon-Only Buttons
+**Learning:** Icon-only buttons using Material Icons ligatures (e.g., `<span ...>vertical_align_top</span>`) often have ligature text that describes the icon visually but not functionally (e.g., "vertical_align_top" vs "Scroll to top").
+**Action:** Always add explicit `aria-label` and `title` attributes to icon-only buttons to ensure screen readers announce the action, not the icon name.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -12,6 +12,7 @@ export const AddButton = (props: {
   node_id: types.TNodeId;
   prefix?: undefined | string;
   id?: string;
+  ariaLabel?: string;
 }) => {
   const dispatch = useDispatch();
   const session = React.use(states.session_key_context);
@@ -25,12 +26,15 @@ export const AddButton = (props: {
     );
     dispatch(actions.focusFirstChildTextAreaActionOf(props.node_id, prefix));
   }, [props.node_id, dispatch, show_mobile, prefix]);
+  const ariaLabel = props.ariaLabel || "Add new item";
   return (
     <button
       className="btn-icon"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label={ariaLabel}
+      title={ariaLabel}
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -367,7 +367,9 @@ export const ToggleShowMobileButton = () => {
     set_show_mobile((v) => !v);
     setShowMobileUpdatedAt(Date.now());
   }, [set_show_mobile, setShowMobileUpdatedAt]);
-  const title = show_mobile ? "Switch to desktop view" : "Switch to mobile view";
+  const title = show_mobile
+    ? "Switch to desktop view"
+    : "Switch to mobile view";
   return (
     <button
       className="btn-icon"

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -110,6 +110,8 @@ const MobileNodeFilterQueryInput = () => {
         className="icon-icon"
         onClick={clear_input}
         onDoubleClick={prevent_propagation}
+        aria-label="Clear filter"
+        title="Clear filter"
       >
         {consts.DELETE_MARK}
       </button>
@@ -167,6 +169,8 @@ const NodeFilterQueryInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear filter"
+          title="Clear filter"
         >
           {consts.DELETE_MARK}
         </button>
@@ -315,6 +319,8 @@ const NodeIdsInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear selected node IDs"
+          title="Clear selected node IDs"
         >
           {consts.DELETE_MARK}
         </button>
@@ -328,6 +334,8 @@ const SBTTB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[60%] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll back to top"
+      title="Scroll back to top"
     >
       {SCROLL_BACK_TO_TOP_MARK}
     </button>
@@ -339,6 +347,8 @@ const SBTBB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[calc(60%+4rem)] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll back to bottom"
+      title="Scroll back to bottom"
     >
       {SCROLL_BACK_TO_BOTTOM_MARK}
     </button>
@@ -357,11 +367,14 @@ export const ToggleShowMobileButton = () => {
     set_show_mobile((v) => !v);
     setShowMobileUpdatedAt(Date.now());
   }, [set_show_mobile, setShowMobileUpdatedAt]);
+  const title = show_mobile ? "Switch to desktop view" : "Switch to mobile view";
   return (
     <button
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
+      aria-label={title}
+      title={title}
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}
     </button>
@@ -424,6 +437,8 @@ const Menu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all tasks"
+        title="Stop all tasks"
       >
         {consts.STOP_MARK}
       </button>
@@ -1132,6 +1147,8 @@ const MobileMenu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all tasks"
+        title="Stop all tasks"
       >
         {consts.STOP_MARK}
       </button>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to several icon-only buttons in the frontend, including `Scroll to Top`, `Scroll to Bottom`, `Switch View`, `Clear Filter`, and `Stop All`. Also updated the reusable `AddButton` component to accept an optional `ariaLabel`.

🎯 Why: These buttons rely on Material Icon ligatures which are visually intuitive but often inaccessible or confusing for screen reader users (e.g., reading "vertical_align_top" instead of "Scroll to top"). Adding explicit labels significantly improves accessibility.

♿ Accessibility:
- Added `aria-label="Scroll back to top"` to SBTTB.
- Added `aria-label="Scroll back to bottom"` to SBTBB.
- Added dynamic label for `ToggleShowMobileButton` ("Switch to desktop view" / "Switch to mobile view").
- Added `aria-label="Clear filter"` to filter inputs.
- Added `aria-label="Stop all tasks"` to stop buttons.
- Added default `aria-label="Add new item"` to `AddButton`.

---
*PR created automatically by Jules for task [8953328334618709246](https://jules.google.com/task/8953328334618709246) started by @kshramt*