### PR TITLE
⚡ Bolt: Add React.memo to QueueEntry for list performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 # production
 **/build/
+**/dist/
+**/dev-dist/
 
 # misc
 .DS_Store

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -22,19 +22,18 @@ import TopButton from "./TopButton";
  * This ensures that items only re-render when their props (node_id, index) change,
  * significantly improving scroll performance and list updates.
  */
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,12 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+/**
+ * Bolt: Wrapped in React.memo to prevent unnecessary re-renders in react-virtuoso list.
+ * This ensures that items only re-render when their props (node_id, index) change,
+ * significantly improving scroll performance and list updates.
+ */
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +34,7 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
This PR implements a performance optimization for the frontend task list.

**Changes:**
- Wrapped `QueueEntry` component in `client/src/QueueEntry.tsx` with `React.memo`.
- Updated `.gitignore` to ignore `**/dist/` and `**/dev-dist/`.

**Why:**
- The `QueueEntry` component is used within a virtualized list (`react-virtuoso`). Without memoization, parent re-renders (e.g., due to scroll or other state changes) can cause all visible items to re-render, leading to performance degradation.
- Explicit `React.memo` is recommended for components rendered by `react-virtuoso`'s `itemContent`.

**Impact:**
- Reduces unnecessary re-renders of list items.
- Improves scrolling smoothness and responsiveness of the task list.

**Verification:**
- Ran `pnpm exec eslint --max-warnings 0 src` (passed).
- Ran `pnpm build` (passed).
- Confirmed `React` import exists in `QueueEntry.tsx`.


---
*PR created automatically by Jules for task [5218703098741549232](https://jules.google.com/task/5218703098741549232) started by @kshramt*