### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing security headers in api_v2

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-12-07 - Axum Security Headers
+**Vulnerability:** Missing default HTTP security headers in Axum.
+**Learning:** Axum v0.7 does not provide default security headers like `X-Content-Type-Options` or `Content-Security-Policy`.
+**Prevention:** Explicitly add `tower_http::set_header::SetResponseHeaderLayer` middleware in the `create_app` function for all services.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,9 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{
+        header::{HeaderName, HeaderValue},
+        request::Parts,
+    },
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -378,6 +381,32 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn create_app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    let app = app
+        .layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-content-type-options"),
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-frame-options"),
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-xss-protection"),
+            HeaderValue::from_static("1; mode=block"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("content-security-policy"),
+            HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'"),
+        ))
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    app
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +414,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = create_app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +424,34 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::Request,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://user:pass@localhost:5432/db")
+            .unwrap();
+        let state = Arc::new(AppState::new(0, pool));
+        let app = create_app(state);
+
+        let response = app
+            .oneshot(Request::builder().uri("/not-found").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+        assert_eq!(headers.get("X-Content-Type-Options").map(|h| h.to_str().unwrap()), Some("nosniff"));
+        assert_eq!(headers.get("X-Frame-Options").map(|h| h.to_str().unwrap()), Some("DENY"));
+        assert_eq!(headers.get("X-XSS-Protection").map(|h| h.to_str().unwrap()), Some("1; mode=block"));
+        assert_eq!(headers.get("Content-Security-Policy").map(|h| h.to_str().unwrap()), Some("default-src 'none'; frame-ancestors 'none'"));
+    }
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -429,10 +429,7 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{
-        body::Body,
-        http::Request,
-    };
+    use axum::{body::Body, http::Request};
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -444,14 +441,35 @@ mod tests {
         let app = create_app(state);
 
         let response = app
-            .oneshot(Request::builder().uri("/not-found").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri("/not-found")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
 
         let headers = response.headers();
-        assert_eq!(headers.get("X-Content-Type-Options").map(|h| h.to_str().unwrap()), Some("nosniff"));
-        assert_eq!(headers.get("X-Frame-Options").map(|h| h.to_str().unwrap()), Some("DENY"));
-        assert_eq!(headers.get("X-XSS-Protection").map(|h| h.to_str().unwrap()), Some("1; mode=block"));
-        assert_eq!(headers.get("Content-Security-Policy").map(|h| h.to_str().unwrap()), Some("default-src 'none'; frame-ancestors 'none'"));
+        assert_eq!(
+            headers
+                .get("X-Content-Type-Options")
+                .map(|h| h.to_str().unwrap()),
+            Some("nosniff")
+        );
+        assert_eq!(
+            headers.get("X-Frame-Options").map(|h| h.to_str().unwrap()),
+            Some("DENY")
+        );
+        assert_eq!(
+            headers.get("X-XSS-Protection").map(|h| h.to_str().unwrap()),
+            Some("1; mode=block")
+        );
+        assert_eq!(
+            headers
+                .get("Content-Security-Policy")
+                .map(|h| h.to_str().unwrap()),
+            Some("default-src 'none'; frame-ancestors 'none'")
+        );
     }
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -21,6 +21,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -385,8 +386,7 @@ fn create_app(state: Arc<AppState>) -> axum::Router {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
             HeaderName::from_static("x-content-type-options"),
             HeaderValue::from_static("nosniff"),
@@ -403,8 +403,7 @@ fn create_app(state: Arc<AppState>) -> axum::Router {
             HeaderName::from_static("content-security-policy"),
             HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'"),
         ))
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
-    app
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
 }
 
 #[tokio::main]


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing HTTP security headers (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Content-Security-Policy).
🎯 Impact: Increased risk of XSS, Clickjacking, and MIME-sniffing attacks.
🔧 Fix: Added `tower_http::set_header::SetResponseHeaderLayer` middleware to `create_app` in `api_v2/src/main.rs`.
✅ Verification: Added a unit test `test_security_headers` that verifies the presence of these headers.

---
*PR created automatically by Jules for task [13530682244393874660](https://jules.google.com/task/13530682244393874660) started by @kshramt*