### PR TITLE
🎨 Palette: Add accessibility labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,12 @@
+# Palette's Journal
+
+This journal documents critical UX and accessibility learnings.
+
+Format:
+## YYYY-MM-DD - [Title]
+**Learning:** [UX/a11y insight]
+**Action:** [How to apply next time]
+
+## 2026-02-18 - Missing Accessibility Labels on Icon Buttons
+**Learning:** Icon-only buttons (using `consts.*_MARK`) frequently lack accessible names (`aria-label`) and tooltips (`title`). This makes the interface confusing for screen reader users and new users.
+**Action:** Enforce `aria-label` and `title` on all icon-only buttons. Prefer the `btn-icon` class for consistency.

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -107,9 +107,11 @@ const MobileNodeFilterQueryInput = () => {
         className="h-[2em] border-none w-[8em]"
       />
       <button
-        className="icon-icon"
+        className="btn-icon"
         onClick={clear_input}
         onDoubleClick={prevent_propagation}
+        aria-label="Clear filter"
+        title="Clear filter"
       >
         {consts.DELETE_MARK}
       </button>
@@ -167,6 +169,8 @@ const NodeFilterQueryInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear filter"
+          title="Clear filter"
         >
           {consts.DELETE_MARK}
         </button>
@@ -315,6 +319,8 @@ const NodeIdsInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear selected IDs"
+          title="Clear selected IDs"
         >
           {consts.DELETE_MARK}
         </button>
@@ -328,6 +334,8 @@ const SBTTB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[60%] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to top"
+      title="Scroll to top"
     >
       {SCROLL_BACK_TO_TOP_MARK}
     </button>
@@ -339,6 +347,8 @@ const SBTBB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[calc(60%+4rem)] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to bottom"
+      title="Scroll to bottom"
     >
       {SCROLL_BACK_TO_BOTTOM_MARK}
     </button>
@@ -357,11 +367,14 @@ export const ToggleShowMobileButton = () => {
     set_show_mobile((v) => !v);
     setShowMobileUpdatedAt(Date.now());
   }, [set_show_mobile, setShowMobileUpdatedAt]);
+  const label = show_mobile ? "Show desktop view" : "Show mobile view";
   return (
     <button
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
+      aria-label={label}
+      title={label}
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}
     </button>
@@ -424,6 +437,8 @@ const Menu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all tasks"
+        title="Stop all tasks"
       >
         {consts.STOP_MARK}
       </button>
@@ -1132,6 +1147,8 @@ const MobileMenu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all tasks"
+        title="Stop all tasks"
       >
         {consts.STOP_MARK}
       </button>


### PR DESCRIPTION
🎨 Palette: Improved accessibility for icon-only buttons

💡 What: Added `aria-label` and `title` attributes to multiple icon-only buttons in `client/src/components.tsx`.
🎯 Why: These buttons relied on Material Icon ligatures (e.g., `close`, `stop`) which are not descriptive for screen readers and lack tooltips for sighted users. This improves accessibility and usability.
📸 Before/After: No visual change except for tooltips on hover.
♿ Accessibility: Screen readers will now announce descriptive names for these buttons (e.g., "Clear filter", "Stop all tasks"). Tooltips provide context for mouse users.

Reference: `.jules/palette.md` for journal entry.

---
*PR created automatically by Jules for task [4900150345043494047](https://jules.google.com/task/4900150345043494047) started by @kshramt*