### PR TITLE
🎨 Palette: Add accessible labels to AddButton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # production
 **/build/
+**/dist/
 
 # misc
 .DS_Store

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-05-22 - Icon-Only Buttons Accessibility Pattern
+**Learning:** The codebase heavily utilizes icon-only buttons (e.g., using `material-icons`) which consistently lack `aria-label` or `title` attributes, making them inaccessible to screen reader users and confusing for mouse users (no tooltip).
+**Action:** Always enforce `aria-label` and `title` props on icon-only button components like `AddButton`, and audit `components.tsx` for similar patterns (e.g., `SBTTB`, `SBTBB`).
+
+## 2024-05-22 - Build Artifact Management
+**Learning:** The repository's `.gitignore` missed `**/dist/`, which is the default output for Vite builds, leading to potential accidental commitment of build artifacts.
+**Action:** Ensure `.gitignore` includes `**/dist/` in Vite-based projects to prevent repository bloat.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -12,6 +12,7 @@ export const AddButton = (props: {
   node_id: types.TNodeId;
   prefix?: undefined | string;
   id?: string;
+  ariaLabel?: string;
 }) => {
   const dispatch = useDispatch();
   const session = React.use(states.session_key_context);
@@ -25,12 +26,15 @@ export const AddButton = (props: {
     );
     dispatch(actions.focusFirstChildTextAreaActionOf(props.node_id, prefix));
   }, [props.node_id, dispatch, show_mobile, prefix]);
+  const label = props.ariaLabel || "Add new item";
   return (
     <button
       className="btn-icon"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label={label}
+      title={label}
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -41,7 +41,13 @@ export const EntryButtons = (props: {
       {is_root || !is_todo || <MoveUpButton node_id={props.node_id} />}
       {is_root || !is_todo || <MoveDownButton node_id={props.node_id} />}
       {/* <DeleteButton node_id={props.node_id} /> */}
-      {is_todo && <AddButton node_id={props.node_id} prefix={props.prefix} />}
+      {is_todo && (
+        <AddButton
+          node_id={props.node_id}
+          prefix={props.prefix}
+          ariaLabel="Add sub-task"
+        />
+      )}
       <ShowDetailsButton node_id={props.node_id} />
       {props.jumpButton}
     </div>

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -427,7 +427,11 @@ const Menu = (props: {
       >
         {consts.STOP_MARK}
       </button>
-      <AddButton node_id={root} id="add-root-button" />
+      <AddButton
+        node_id={root}
+        id="add-root-button"
+        ariaLabel="Add new root item"
+      />
       <button
         className="btn-icon"
         aria-label="Undo."
@@ -1135,7 +1139,7 @@ const MobileMenu = (props: {
       >
         {consts.STOP_MARK}
       </button>
-      <AddButton node_id={root} />
+      <AddButton node_id={root} ariaLabel="Add new root item" />
       <button
         className="btn-icon"
         aria-label="Undo."
@@ -1329,7 +1333,9 @@ const MobileEntryButtons = (props: { node_id: types.TNodeId }) => {
         {is_root || status !== "todo" || <TopButton node_id={props.node_id} />}
         {/* <DeleteButton node_id={props.node_id} /> */}
         <CopyNodeIdButton node_id={props.node_id} />
-        {status === "todo" && <AddButton node_id={props.node_id} />}
+        {status === "todo" && (
+          <AddButton node_id={props.node_id} ariaLabel="Add sub-task" />
+        )}
         <ShowDetailsButton node_id={props.node_id} />
         <TotalTime node_id={props.node_id} />
         {is_root || <LastRange node_id={props.node_id} />}


### PR DESCRIPTION
Implemented accessible labels for the `AddButton` component and updated its usages across the application to provide context-specific labels. Also updated `.gitignore` to exclude build artifacts.

---
*PR created automatically by Jules for task [15421242017810078595](https://jules.google.com/task/15421242017810078595) started by @kshramt*