### PR TITLE
🛡️ Sentinel: [HIGH] Add security headers to API responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - [Security Headers & Testing Pattern]
+**Vulnerability:** API responses lacked standard security headers (CSP, X-Content-Type-Options, X-Frame-Options), increasing risk of XSS and Clickjacking.
+**Learning:** `api_v2` was structured with `main` doing all setup, making it hard to test middleware without a running DB. Refactoring to `create_app` enables `tower::ServiceExt::oneshot` testing with lazy DB connections.
+**Prevention:** Always extract app construction into a testable function. Use `tower_http::set_header::SetResponseHeaderLayer` for default security headers.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -378,6 +378,30 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn create_app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static("default-src 'none'"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_XSS_PROTECTION,
+            axum::http::HeaderValue::from_static("1; mode=block"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +409,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = create_app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +419,51 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower::ServiceExt;
+    use axum::http::Request;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        // Create a lazy pool that won't connect immediately
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://fake:fake@localhost:5432/fake")
+            .unwrap();
+        let state = Arc::new(AppState::new(0, pool));
+        let app = create_app(state);
+
+        // Make a request to a 404 endpoint to avoid DB queries
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/not-found")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Check headers
+        let headers = response.headers();
+        assert_eq!(
+            headers.get(axum::http::header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'"
+        );
+        assert_eq!(
+            headers.get(axum::http::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            headers.get(axum::http::header::X_FRAME_OPTIONS).unwrap(),
+            "DENY"
+        );
+        assert_eq!(
+            headers.get(axum::http::header::X_XSS_PROTECTION).unwrap(),
+            "1; mode=block"
+        );
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Add security headers to API responses

**Vulnerability:**
The API responses were missing standard security headers, which are best practice for preventing XSS, Clickjacking, and MIME sniffing attacks.

**Impact:**
- **Missing CSP:** Increases risk of XSS if the API ever serves HTML or if vulnerabilities exist in the client consuming it.
- **Missing X-Frame-Options:** Allows the API (if rendered in browser) to be embedded in iframes, risking clickjacking.
- **Missing X-Content-Type-Options:** Allows browsers to MIME-sniff the response, potentially executing non-executable content as scripts.

**Fix:**
- Implemented `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs`.
- Added the following headers:
    - `Content-Security-Policy: default-src 'none'`
    - `X-Content-Type-Options: nosniff`
    - `X-Frame-Options: DENY`
    - `X-XSS-Protection: 1; mode=block`
- Refactored `main` to extract `create_app` function, enabling unit testing of the router and middleware without a running database (using `connect_lazy`).

**Verification:**
- Run `cd api_v2 && cargo test` to execute the new `test_security_headers` unit test.


---
*PR created automatically by Jules for task [6944242850854147379](https://jules.google.com/task/6944242850854147379) started by @kshramt*