### PR TITLE
🛡️ Sentinel: [Security Enhancement] Add standard security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - [Missing Security Headers in API]
+**Vulnerability:** The API (`api_v2`) was serving responses without standard security headers (`Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`).
+**Learning:** Axum, unlike some other frameworks, does not set these headers by default. Explicit middleware is required.
+**Prevention:** Always use `tower_http::set_header::SetResponseHeaderLayer` or similar middleware to enforce security defaults in Axum applications.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -384,30 +384,22 @@ fn create_app(state: Arc<AppState>) -> axum::Router {
     let app = app.with_state(state);
     app.layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
-        .layer(
-            tower_http::set_header::SetResponseHeaderLayer::overriding(
-                axum::http::header::X_CONTENT_TYPE_OPTIONS,
-                axum::http::HeaderValue::from_static("nosniff"),
-            ),
-        )
-        .layer(
-            tower_http::set_header::SetResponseHeaderLayer::overriding(
-                axum::http::header::X_FRAME_OPTIONS,
-                axum::http::HeaderValue::from_static("DENY"),
-            ),
-        )
-        .layer(
-            tower_http::set_header::SetResponseHeaderLayer::overriding(
-                axum::http::header::X_XSS_PROTECTION,
-                axum::http::HeaderValue::from_static("1; mode=block"),
-            ),
-        )
-        .layer(
-            tower_http::set_header::SetResponseHeaderLayer::overriding(
-                axum::http::header::CONTENT_SECURITY_POLICY,
-                axum::http::HeaderValue::from_static("default-src 'none'"),
-            ),
-        )
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_XSS_PROTECTION,
+            axum::http::HeaderValue::from_static("1; mode=block"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static("default-src 'none'"),
+        ))
 }
 
 #[tokio::main]
@@ -432,10 +424,7 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{
-        body::Body,
-        http::{Request},
-    };
+    use axum::{body::Body, http::Request};
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -448,7 +437,12 @@ mod tests {
         let app = create_app(state);
 
         let response = app
-            .oneshot(Request::builder().uri("/api/v2/sys/health").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v2/sys/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
 
@@ -457,6 +451,9 @@ mod tests {
         assert_eq!(headers.get("X-Content-Type-Options").unwrap(), "nosniff");
         assert_eq!(headers.get("X-Frame-Options").unwrap(), "DENY");
         assert_eq!(headers.get("X-XSS-Protection").unwrap(), "1; mode=block");
-        assert_eq!(headers.get("Content-Security-Policy").unwrap(), "default-src 'none'");
+        assert_eq!(
+            headers.get("Content-Security-Policy").unwrap(),
+            "default-src 'none'"
+        );
     }
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -378,6 +378,38 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn create_app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::X_CONTENT_TYPE_OPTIONS,
+                axum::http::HeaderValue::from_static("nosniff"),
+            ),
+        )
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::X_FRAME_OPTIONS,
+                axum::http::HeaderValue::from_static("DENY"),
+            ),
+        )
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::X_XSS_PROTECTION,
+                axum::http::HeaderValue::from_static("1; mode=block"),
+            ),
+        )
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::CONTENT_SECURITY_POLICY,
+                axum::http::HeaderValue::from_static("default-src 'none'"),
+            ),
+        )
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +417,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = create_app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +427,36 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request},
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        // Mock state with lazy pool
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://localhost:5432/test")
+            .unwrap();
+        let state = Arc::new(AppState::new(0, pool));
+        let app = create_app(state);
+
+        let response = app
+            .oneshot(Request::builder().uri("/api/v2/sys/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        // Check headers
+        let headers = response.headers();
+        assert_eq!(headers.get("X-Content-Type-Options").unwrap(), "nosniff");
+        assert_eq!(headers.get("X-Frame-Options").unwrap(), "DENY");
+        assert_eq!(headers.get("X-XSS-Protection").unwrap(), "1; mode=block");
+        assert_eq!(headers.get("Content-Security-Policy").unwrap(), "default-src 'none'");
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel: [Security Enhancement] Add standard security headers

**Security Enhancement:**
Added standard security headers to the `api_v2` application responses to mitigate common web vulnerabilities.
- `Content-Security-Policy: default-src 'none'`: Prevents execution of unauthorized scripts and resources.
- `X-Frame-Options: DENY`: Protects against clickjacking.
- `X-Content-Type-Options: nosniff`: Prevents MIME-sniffing attacks.
- `X-XSS-Protection: 1; mode=block`: Enables browser XSS filtering.

**Changes:**
- Refactored `api_v2/src/main.rs` to extract the application creation logic into a `create_app` function.
- Added `tower_http::set_header::SetResponseHeaderLayer` middleware to `create_app`.
- Added a unit test `test_security_headers` in `api_v2/src/main.rs` to verify the headers are correctly applied.
- Created `.jules/sentinel.md` with a journal entry documenting the enhancement.

**Verification:**
- Run `cargo test -p api_v2` to verify the new test passes.
- Run `cargo check -p api_v2` to ensure no build errors.

---
*PR created automatically by Jules for task [15793164094048725669](https://jules.google.com/task/15793164094048725669) started by @kshramt*