### PR TITLE
🎨 Palette: Add accessibility attributes to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Inaccessible Icon-Only Buttons]
+**Learning:** Found a pattern of icon-only buttons (like `SBTTB`, `SBTBB`, `ToggleShowMobileButton`, and various timeline controls) lacking `aria-label` and `title` attributes, making them inaccessible to screen readers and confusing for mouse users without tooltips.
+**Action:** Always add `aria-label` and `title` to icon-only buttons during development or refactoring, specifically targeting custom components in `client/src/components.tsx`.

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -107,9 +107,11 @@ const MobileNodeFilterQueryInput = () => {
         className="h-[2em] border-none w-[8em]"
       />
       <button
-        className="icon-icon"
+        className="btn-icon"
         onClick={clear_input}
         onDoubleClick={prevent_propagation}
+        aria-label="Clear filter"
+        title="Clear filter"
       >
         {consts.DELETE_MARK}
       </button>
@@ -167,6 +169,8 @@ const NodeFilterQueryInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear filter"
+          title="Clear filter"
         >
           {consts.DELETE_MARK}
         </button>
@@ -315,6 +319,8 @@ const NodeIdsInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear IDs"
+          title="Clear IDs"
         >
           {consts.DELETE_MARK}
         </button>
@@ -328,6 +334,8 @@ const SBTTB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[60%] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to top"
+      title="Scroll to top"
     >
       {SCROLL_BACK_TO_TOP_MARK}
     </button>
@@ -339,6 +347,8 @@ const SBTBB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[calc(60%+4rem)] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll to bottom"
+      title="Scroll to bottom"
     >
       {SCROLL_BACK_TO_BOTTOM_MARK}
     </button>
@@ -357,11 +367,16 @@ export const ToggleShowMobileButton = () => {
     set_show_mobile((v) => !v);
     setShowMobileUpdatedAt(Date.now());
   }, [set_show_mobile, setShowMobileUpdatedAt]);
+  const title = show_mobile
+    ? "Switch to desktop view"
+    : "Switch to mobile view";
   return (
     <button
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
+      aria-label={title}
+      title={title}
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}
     </button>
@@ -424,6 +439,8 @@ const Menu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all tasks"
+        title="Stop all tasks"
       >
         {consts.STOP_MARK}
       </button>
@@ -578,7 +595,12 @@ const Timeline = () => {
   return (
     <>
       {decade_nodes}
-      <button className="btn-icon" onClick={increment_count}>
+      <button
+        className="btn-icon"
+        onClick={increment_count}
+        aria-label="Add time node"
+        title="Add time node"
+      >
         {consts.ADD_MARK}
       </button>
     </>
@@ -785,13 +807,23 @@ const TimeNodeEntry = (props: { time_node_id: types.TTimeNodeId }) => {
       />
       {isOn && (
         <div className="flex w-fit gap-x-[0.125em]">
-          <button className="btn-icon" onClick={assign_nodes}>
+          <button
+            className="btn-icon"
+            onClick={assign_nodes}
+            aria-label="Assign selected nodes"
+            title="Assign selected nodes"
+          >
             {consts.ADD_MARK}
           </button>
           <CopyDescendantTimeNodesPlannedNodeIdsButton
             time_node_id={props.time_node_id}
           />
-          <button className="btn-icon" onClick={toggle_show_children}>
+          <button
+            className="btn-icon"
+            onClick={toggle_show_children}
+            aria-label="Toggle children visibility"
+            title="Toggle children visibility"
+          >
             {time_node === undefined || time_node.show_children === "partial"
               ? consts.IS_PARTIAL_MARK
               : time_node.show_children === "full"
@@ -863,7 +895,12 @@ const PlannedNode = (props: {
             </>
           )}
           <CopyNodeIdButton node_id={props.node_id} />
-          <button className="btn-icon" onClick={unassign_node}>
+          <button
+            className="btn-icon"
+            onClick={unassign_node}
+            aria-label="Unassign node"
+            title="Unassign node"
+          >
             {consts.DELETE_MARK}
           </button>
         </div>
@@ -1132,6 +1169,8 @@ const MobileMenu = (props: {
         className="btn-icon"
         onClick={stop_all}
         onDoubleClick={prevent_propagation}
+        aria-label="Stop all tasks"
+        title="Stop all tasks"
       >
         {consts.STOP_MARK}
       </button>
@@ -1457,6 +1496,8 @@ const CopyDescendantTimeNodesPlannedNodeIdsButton = (props: {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={prevent_propagation}
+      aria-label="Copy descendant node IDs"
+      title="Copy descendant node IDs"
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to numerous icon-only buttons in `client/src/components.tsx`.
🎯 Why: These buttons were inaccessible to screen readers and lacked tooltips for mouse users, making the interface confusing.
♿ Accessibility:
- Added labels to `SBTTB` (Scroll Back To Top) and `SBTBB` (Scroll Back To Bottom).
- Added dynamic label to `ToggleShowMobileButton`.
- Added labels to clear buttons in `NodeFilterQueryInput`, `MobileNodeFilterQueryInput`, and `NodeIdsInput`.
- Added labels to 'Stop all' buttons in Menu.
- Added labels to Timeline 'Add', 'Assign', 'Toggle Children', and 'Unassign' buttons.
- Added label to `CopyDescendantTimeNodesPlannedNodeIdsButton`.
- Standardized class name for `MobileNodeFilterQueryInput` clear button to `btn-icon`.

Verified with lint, build, and partial frontend inspection.

---
*PR created automatically by Jules for task [14977749395936353058](https://jules.google.com/task/14977749395936353058) started by @kshramt*