### PR TITLE
Add security headers to api_v2

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-11-20 - [Missing Security Headers in Backend API]
+**Vulnerability:** The `api_v2` service was missing standard security headers (`Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Strict-Transport-Security`). This exposed the API to potential XSS, clickjacking, and MIME sniffing attacks, relying solely on upstream proxies which might not be consistently configured.
+**Learning:** Security headers should be enforced at the application level (defense in depth) rather than relying solely on infrastructure (like Envoy/Nginx), ensuring protection regardless of deployment topology.
+**Prevention:** Implemented `tower_http::set_header::SetResponseHeaderLayer` middleware in `api_v2/src/main.rs` to enforce these headers on all responses.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{header, request::Parts, HeaderValue},
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -390,6 +390,26 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::X_XSS_PROTECTION,
+            HeaderValue::from_static("1; mode=block"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 
     let port = get_server_port();


### PR DESCRIPTION
**Vulnerability:** The `api_v2` service was missing standard security headers (`Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Strict-Transport-Security`). This exposed the API to potential XSS, clickjacking, and MIME sniffing attacks.

**Fix:** Implemented `tower_http::set_header::SetResponseHeaderLayer` middleware in `api_v2/src/main.rs` to enforce these headers on all responses.

**Verification:** Verified compilation with `cargo check`. The headers are now configured to be sent with every response.


---
*PR created automatically by Jules for task [8402310459377509248](https://jules.google.com/task/8402310459377509248) started by @kshramt*