### PR TITLE
⚡ Bolt: Memoize QueueEntry component

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-## 2025-02-19 - React.memo for Virtualized List Items
-**Learning:** `QueueEntry` component used in `react-virtuoso` lists was not memoized, causing unnecessary re-renders when parent components updated, despite `Virtuoso` handling list virtualization.
-**Action:** Always ensure components rendered via `itemContent` in virtualization libraries are wrapped in `React.memo` (or similar) if they rely on props that are stable (like IDs) but are re-created by parent renders.
+## 2025-02-19 - Prettier Formatting Check
+**Learning:** The CI pipeline runs `prettier --check src` which fails if files are not formatted. Always run `pnpm exec prettier --write src` or configure your editor to format on save before committing.
+**Action:** Added a verification step to run prettier check locally before submitting.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-19 - React.memo for Virtualized List Items
+**Learning:** `QueueEntry` component used in `react-virtuoso` lists was not memoized, causing unnecessary re-renders when parent components updated, despite `Virtuoso` handling list virtualization.
+**Action:** Always ensure components rendered via `itemContent` in virtualization libraries are wrapped in `React.memo` (or similar) if they rely on props that are stable (like IDs) but are re-created by parent renders.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,9 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+// ⚡ Bolt: Wrapped in React.memo to prevent unnecessary re-renders when parent updates
+// but props (node_id, index) remain the same.
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +31,7 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -19,19 +19,18 @@ import TopButton from "./TopButton";
 
 // ⚡ Bolt: Wrapped in React.memo to prevent unnecessary re-renders when parent updates
 // but props (node_id, index) remain the same.
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped QueueEntry component in React.memo.
🎯 Why: Prevents unnecessary re-renders of list items when parent components update but item props (node_id, index) remain unchanged.
📊 Impact: Reduces re-renders of potentially hundreds of list items during filtering or unrelated state updates.
🔬 Measurement: Verified via build and lint. Expected smoother scrolling and list updates.

---
*PR created automatically by Jules for task [7283197544576953755](https://jules.google.com/task/7283197544576953755) started by @kshramt*