### PR TITLE
🎨 Palette: Add labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Icon Button Accessibility Gap
+**Learning:** The codebase consistently uses `material-icons` inside buttons (class `btn-icon`) without `aria-label` or `title` attributes, rendering core actions (Add, Start, Stop) inaccessible to screen readers and unclear to sighted users.
+**Action:** Systematically audit all components using `.btn-icon` and enforce `aria-label` (for screen readers) and `title` (for tooltips) on these elements.

--- a/client/dev-dist/registerSW.js
+++ b/client/dev-dist/registerSW.js
@@ -1,0 +1,1 @@
+if('serviceWorker' in navigator) navigator.serviceWorker.register('/dev-sw.js?dev-sw', { scope: '/', type: 'classic' })

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -12,6 +12,7 @@ export const AddButton = (props: {
   node_id: types.TNodeId;
   prefix?: undefined | string;
   id?: string;
+  ariaLabel?: string;
 }) => {
   const dispatch = useDispatch();
   const session = React.use(states.session_key_context);
@@ -25,12 +26,15 @@ export const AddButton = (props: {
     );
     dispatch(actions.focusFirstChildTextAreaActionOf(props.node_id, prefix));
   }, [props.node_id, dispatch, show_mobile, prefix]);
+  const ariaLabel = props.ariaLabel || "Add new item";
   return (
     <button
       className="btn-icon"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label={ariaLabel}
+      title={ariaLabel}
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up"
+      title="Move up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down"
+      title="Move down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrent"
+      title="Start concurrent"
     >
       {consts.START_CONCURRNET_MARK}
     </button>


### PR DESCRIPTION
Added `aria-label` and `title` to several icon-only buttons to improve accessibility and usability.
Specifically targeted `AddButton`, `StartButton`, `StartConcurrentButton`, `MoveUpButton`, and `MoveDownButton`.
This addresses the issue where icon-only buttons were inaccessible to screen readers and lacked tooltips.

---
*PR created automatically by Jules for task [8961461674067938650](https://jules.google.com/task/8961461674067938650) started by @kshramt*