### PR TITLE
🛡️ Sentinel: Add security headers and document critical auth vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - [Critical Authentication Vulnerability: Fake IDP]
+**Vulnerability:** The application relies entirely on a "Fake IDP" for authentication, which uses unsigned, base64-encoded JSON tokens (`{"user_id": "..."}`) and exposes endpoints (`/fake_idp/*`) allowing arbitrary user impersonation.
+**Learning:** The `client` application is hardcoded to use these endpoints, making it impossible to disable them without breaking core functionality. The "Fake IDP" is not just a development tool but the *only* authentication mechanism.
+**Prevention:** In a real production environment, a proper OIDC/OAuth2 provider must replace this system. Token validation must include signature verification. This requires a significant refactor of both `api_v2` and `client`. Currently, we are mitigating risks by adding defense-in-depth measures (security headers) until a full auth rewrite is prioritized.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -391,36 +391,26 @@ async fn main() {
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
-        .layer(
-            tower_http::set_header::SetResponseHeaderLayer::overriding(
-                axum::http::header::CONTENT_SECURITY_POLICY,
-                HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'"),
-            ),
-        )
-        .layer(
-            tower_http::set_header::SetResponseHeaderLayer::overriding(
-                axum::http::header::STRICT_TRANSPORT_SECURITY,
-                HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
-            ),
-        )
-        .layer(
-            tower_http::set_header::SetResponseHeaderLayer::overriding(
-                axum::http::header::X_CONTENT_TYPE_OPTIONS,
-                HeaderValue::from_static("nosniff"),
-            ),
-        )
-        .layer(
-            tower_http::set_header::SetResponseHeaderLayer::overriding(
-                axum::http::header::X_FRAME_OPTIONS,
-                HeaderValue::from_static("DENY"),
-            ),
-        )
-        .layer(
-            tower_http::set_header::SetResponseHeaderLayer::overriding(
-                axum::http::header::X_XSS_PROTECTION,
-                HeaderValue::from_static("1; mode=block"),
-            ),
-        );
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_XSS_PROTECTION,
+            HeaderValue::from_static("1; mode=block"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{request::Parts, HeaderValue},
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -390,7 +390,37 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::CONTENT_SECURITY_POLICY,
+                HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'"),
+            ),
+        )
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::STRICT_TRANSPORT_SECURITY,
+                HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+            ),
+        )
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::X_CONTENT_TYPE_OPTIONS,
+                HeaderValue::from_static("nosniff"),
+            ),
+        )
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::X_FRAME_OPTIONS,
+                HeaderValue::from_static("DENY"),
+            ),
+        )
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::X_XSS_PROTECTION,
+                HeaderValue::from_static("1; mode=block"),
+            ),
+        );
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🛡️ Sentinel Report:

**Security Enhancement:**
Added critical HTTP security headers to `api_v2` to improve defense-in-depth:
- `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'`
- `Strict-Transport-Security` (HSTS)
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `X-XSS-Protection: 1; mode=block`

**Critical Finding:**
Identified that the application relies entirely on an insecure "Fake IDP" mechanism for authentication. This cannot be fixed without a major refactor and breaking changes, as the client strictly depends on it. A journal entry in `.jules/sentinel.md` has been created to document this risk.

---
*PR created automatically by Jules for task [3693876261058798185](https://jules.google.com/task/3693876261058798185) started by @kshramt*