### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 # production
 **/build/
+**/dist/
+**/dev-dist/
 
 # misc
 .DS_Store

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - [Consolidating Icon Button Classes]
+**Learning:** The codebase contained inconsistent usage of `icon-icon` and `btn-icon` for icon-only buttons. `btn-icon` is the standard class defined in `lib.css` and provides proper styling for dark mode and hover states.
+**Action:** Always use `btn-icon` for icon-only buttons instead of `icon-icon` or custom inline styles unless specific positioning requires otherwise (like `SBTTB`).

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -107,9 +107,11 @@ const MobileNodeFilterQueryInput = () => {
         className="h-[2em] border-none w-[8em]"
       />
       <button
-        className="icon-icon"
+        className="btn-icon"
         onClick={clear_input}
         onDoubleClick={prevent_propagation}
+        aria-label="Clear filter"
+        title="Clear filter"
       >
         {consts.DELETE_MARK}
       </button>
@@ -167,6 +169,8 @@ const NodeFilterQueryInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear filter"
+          title="Clear filter"
         >
           {consts.DELETE_MARK}
         </button>
@@ -315,6 +319,8 @@ const NodeIdsInput = () => {
           className="btn-icon"
           onClick={clear_input}
           onDoubleClick={prevent_propagation}
+          aria-label="Clear selected IDs"
+          title="Clear selected IDs"
         >
           {consts.DELETE_MARK}
         </button>
@@ -328,6 +334,8 @@ const SBTTB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[60%] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll back to top"
+      title="Scroll back to top"
     >
       {SCROLL_BACK_TO_TOP_MARK}
     </button>
@@ -339,6 +347,8 @@ const SBTBB = (props: { onClick: () => void }) => {
     <button
       onClick={props.onClick}
       className="sticky top-[calc(60%+4rem)] left-[50%] -translate-x-1/2 -translate-y-1/2 px-[0.15rem] dark:bg-neutral-300 bg-neutral-600 dark:hover:bg-neutral-400 hover:bg-neutral-500 text-center min-w-[3rem] h-[3rem] text-[2rem] border-none shadow-none opacity-70 hover:opacity-100 float-left mt-[-3rem] z-40"
+      aria-label="Scroll back to bottom"
+      title="Scroll back to bottom"
     >
       {SCROLL_BACK_TO_BOTTOM_MARK}
     </button>
@@ -362,6 +372,10 @@ export const ToggleShowMobileButton = () => {
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={prevent_propagation}
+      aria-label={
+        show_mobile ? "Switch to desktop view" : "Switch to mobile view"
+      }
+      title={show_mobile ? "Switch to desktop view" : "Switch to mobile view"}
     >
       {show_mobile ? consts.DESKTOP_MARK : consts.MOBILE_MARK}
     </button>


### PR DESCRIPTION
💡 What: Added aria-labels and titles to several icon-only buttons in client/src/components.tsx. Replaced inconsistent icon-icon class with standard btn-icon.
🎯 Why: Improves accessibility for screen reader users and usability for all users via tooltips. Standardizes button styling.
♿ Accessibility: Added labels to Filter Clear, Scroll To Top/Bottom, and Toggle Mobile View buttons.

---
*PR created automatically by Jules for task [5872265911280739948](https://jules.google.com/task/5872265911280739948) started by @kshramt*