### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing security headers in api_v2

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - [Missing Security Headers in Axum]
+**Vulnerability:** The Axum backend (`api_v2`) lacked standard security headers (CSP, HSTS, X-Frame-Options, etc.), relying partially on Nginx but leaving direct API access vulnerable.
+**Learning:** Axum (and `tower-http`) does not apply security headers by default. They must be explicitly added via middleware layers.
+**Prevention:** Always verify security headers on API responses directly, not just via the ingress proxy. Use `tower_http::set_header::SetResponseHeaderLayer` to enforce them at the application level.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -378,6 +378,38 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn create_app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static(
+                "max-age=63072000; includeSubDomains; preload",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +417,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = create_app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +427,59 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://user:password@localhost:5432/db")
+            .unwrap();
+
+        let state = Arc::new(AppState::new(0, pool));
+        let app = create_app(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v2/not-found")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get(axum::http::header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers.get(axum::http::header::STRICT_TRANSPORT_SECURITY).unwrap(),
+            "max-age=63072000; includeSubDomains; preload"
+        );
+        assert_eq!(
+            headers.get(axum::http::header::X_FRAME_OPTIONS).unwrap(),
+            "DENY"
+        );
+        assert_eq!(
+            headers.get(axum::http::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            headers.get(axum::http::header::REFERRER_POLICY).unwrap(),
+            "no-referrer"
+        );
+    }
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -392,9 +392,7 @@ fn create_app(state: Arc<AppState>) -> axum::Router {
         ))
         .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
             axum::http::header::STRICT_TRANSPORT_SECURITY,
-            axum::http::HeaderValue::from_static(
-                "max-age=63072000; includeSubDomains; preload",
-            ),
+            axum::http::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
         ))
         .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
             axum::http::header::X_FRAME_OPTIONS,
@@ -462,11 +460,15 @@ mod tests {
         let headers = response.headers();
 
         assert_eq!(
-            headers.get(axum::http::header::CONTENT_SECURITY_POLICY).unwrap(),
+            headers
+                .get(axum::http::header::CONTENT_SECURITY_POLICY)
+                .unwrap(),
             "default-src 'none'; frame-ancestors 'none'; sandbox"
         );
         assert_eq!(
-            headers.get(axum::http::header::STRICT_TRANSPORT_SECURITY).unwrap(),
+            headers
+                .get(axum::http::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
             "max-age=63072000; includeSubDomains; preload"
         );
         assert_eq!(
@@ -474,7 +476,9 @@ mod tests {
             "DENY"
         );
         assert_eq!(
-            headers.get(axum::http::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            headers
+                .get(axum::http::header::X_CONTENT_TYPE_OPTIONS)
+                .unwrap(),
             "nosniff"
         );
         assert_eq!(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The API backend (api_v2) was missing standard security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy), leaving it potentially vulnerable to various attacks like clickjacking, MIME sniffing, and HTTPS downgrade if accessed directly.
🎯 Impact: Attackers could potentially frame the API response, sniff content types, or downgrade HTTPS connections.
🔧 Fix: Added tower_http::set_header::SetResponseHeaderLayer middleware to the Axum application to enforce these headers.
✅ Verification: Added a unit test test_security_headers in api_v2/src/main.rs that verifies the presence of these headers on responses.

---
*PR created automatically by Jules for task [2080084408859771620](https://jules.google.com/task/2080084408859771620) started by @kshramt*