### PR TITLE
Enhance CopyNodeIdButton accessibility and UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-26 - Hidden Button Functionality Exposure
+**Learning:** Icon-only buttons with modifier key (Ctrl/Meta) behaviors are completely undiscoverable without a tooltip explaining the interaction.
+**Action:** Always verify if an icon-only button has complex click handlers (e.g., checking `e.ctrlKey`) and add a descriptive `title` attribute detailing the shortcut.

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -25,6 +25,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      title="Copy Node ID (Ctrl+Click to append)"
+      aria-label={is_copied ? "Copied!" : "Copy Node ID"}
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>


### PR DESCRIPTION
This change improves the accessibility and usability of the `CopyNodeIdButton` component.

*   Added `title` attribute to explain the hidden functionality of appending node IDs via `Ctrl+Click`.
*   Added `aria-label` attribute to provide a descriptive name for screen readers, which dynamically updates to "Copied!" for feedback.
*   Documented learning about exposing hidden button behaviors in `.jules/palette.md`.

Verified locally with Playwright script (verified tooltip and aria-label presence). Note: Existing test failures in `vitest` (unrelated to this change) persist.

---
*PR created automatically by Jules for task [15035809429113021809](https://jules.google.com/task/15035809429113021809) started by @kshramt*