### PR TITLE
🛡️ Sentinel: [Security Improvement] Add Security Headers

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,7 +1,7 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
-    Json, RequestPartsExt,
+    http::{request::Parts, HeaderValue},
+    Json, RequestPartsExt, Router,
 };
 use axum_extra::{
     headers::{authorization::Bearer, Authorization},
@@ -13,6 +13,7 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
@@ -378,6 +379,34 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+fn create_app(state: Arc<AppState>) -> Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            HeaderValue::from_static("no-referrer"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +414,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = create_app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +424,47 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use sqlx::postgres::PgPoolOptions;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        // Setup a lazy pool that doesn't actually connect
+        let pool = PgPoolOptions::new()
+            .connect_lazy("postgres://user:pass@localhost:5432/db")
+            .unwrap();
+        let state = Arc::new(AppState::new(0, pool));
+        let app = create_app(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v2/not-found")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+
+        assert_eq!(headers.get("X-Frame-Options").unwrap(), "DENY");
+        assert_eq!(headers.get("X-Content-Type-Options").unwrap(), "nosniff");
+        assert_eq!(
+            headers.get("Content-Security-Policy").unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers.get("Strict-Transport-Security").unwrap(),
+            "max-age=63072000; includeSubDomains; preload"
+        );
+        assert_eq!(headers.get("Referrer-Policy").unwrap(), "no-referrer");
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel: [Security Improvement] Add Security Headers

🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in API responses.
🎯 Impact: While the API is primarily JSON-based, missing headers like HSTS, CSP, and X-Content-Type-Options can leave the application vulnerable to protocol downgrade attacks, MIME sniffing, and potential framing attacks if HTML content is ever served or if the API is accessed directly by a browser.
🔧 Fix:
- Added `tower_http::set_header::SetResponseHeaderLayer` middleware to the Axum router in `api_v2`.
- Configured strict defaults: `HSTS` (2 years), `CSP` (default-src 'none'), `X-Frame-Options` (DENY), `X-Content-Type-Options` (nosniff), and `Referrer-Policy` (no-referrer).
- Refactored `api_v2/src/main.rs` to separate app creation (`create_app`) from the `main` entry point to enable unit testing.
✅ Verification:
- Added `test_security_headers` unit test in `api_v2/src/main.rs` which spins up the app with a lazy DB connection and asserts the presence and values of all security headers on a 404 response.
- Ran `cargo test` (passed).
- Ran `cargo fmt` and `cargo clippy` (passed).

---
*PR created automatically by Jules for task [9321720469111776278](https://jules.google.com/task/9321720469111776278) started by @kshramt*