### PR TITLE
🎨 Palette: Add accessible labels to icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -12,6 +12,7 @@ export const AddButton = (props: {
   node_id: types.TNodeId;
   prefix?: undefined | string;
   id?: string;
+  ariaLabel?: string;
 }) => {
   const dispatch = useDispatch();
   const session = React.use(states.session_key_context);
@@ -25,12 +26,15 @@ export const AddButton = (props: {
     );
     dispatch(actions.focusFirstChildTextAreaActionOf(props.node_id, prefix));
   }, [props.node_id, dispatch, show_mobile, prefix]);
+  const ariaLabel = props.ariaLabel ?? "Add new item";
   return (
     <button
       className="btn-icon"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label={ariaLabel}
+      title={ariaLabel}
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/Calendar/AddButton.tsx
+++ b/client/src/Calendar/AddButton.tsx
@@ -19,7 +19,12 @@ const AddButton = (props: { timeId: string }) => {
     );
   }, [dispatch, props.timeId, nodeIds]);
   return (
-    <button className="btn-icon" onClick={handleClick}>
+    <button
+      className="btn-icon"
+      onClick={handleClick}
+      aria-label="Add selected nodes to this time slot"
+      title="Add selected nodes to this time slot"
+    >
       {consts.ADD_MARK}
     </button>
   );

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -25,6 +25,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Copy Node ID"
+      title="Copy Node ID"
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -16,6 +16,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Restore to Todo"
+      title="Restore to Todo"
     >
       {consts.UNDO_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up"
+      title="Move up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down"
+      title="Move down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -17,6 +17,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Evaluate"
+      title="Evaluate"
     >
       {consts.EVAL_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrently"
+      title="Start concurrently"
     >
       {consts.START_CONCURRNET_MARK}
     </button>

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -20,6 +20,7 @@ const StopButton = ({
     <button
       className="btn-icon"
       aria-label="Stop."
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Mark as done"
+      title="Mark as done"
     >
       {consts.DONE_MARK}
     </button>

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Delete"
+      title="Delete"
     >
       {consts.DONT_MARK}
     </button>

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -16,6 +16,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}
+      aria-label="Move to top"
+      title="Move to top"
     >
       {consts.TOP_MARK}
     </button>


### PR DESCRIPTION
This PR enhances the accessibility of the application by adding `aria-label` and `title` attributes to various icon-only buttons. This ensures that screen reader users can understand the purpose of these controls and provides tooltips for mouse users.

**Changes:**
- **`client/src/AddButton.tsx`**: Added `ariaLabel` prop (defaulting to "Add new item") and applied it to `aria-label` and `title`.
- **`client/src/Calendar/AddButton.tsx`**: added label "Add selected nodes to this time slot".
- **`client/src/StartButton/index.tsx`**: Added label "Start".
- **`client/src/StopButton/index.tsx`**: Added title "Stop" (already had `aria-label`).
- **`client/src/StartConcurrentButton/index.tsx`**: Added label "Start concurrently".
- **`client/src/TopButton/index.tsx`**: Added label "Move to top".
- **`client/src/EvalButton.tsx`**: Added label "Evaluate".
- **`client/src/TodoToDoneButton.tsx`**: Added label "Mark as done".
- **`client/src/TodoToDontButton.tsx`**: Added label "Delete".
- **`client/src/DoneOrDontToTodoButton.tsx`**: Added label "Restore to Todo".
- **`client/src/EntryButtons.tsx`**: Added labels "Move up" and "Move down" to internal buttons.
- **`client/src/CopyNodeIdButton/index.tsx`**: Added label "Copy Node ID".

**Verification:**
- Ran `pnpm lint` and `pnpm build` in `client/` successfully.
- Manually verified code changes for correctness and consistency.


---
*PR created automatically by Jules for task [13662026354264955021](https://jules.google.com/task/13662026354264955021) started by @kshramt*