### PR TITLE
⚡ Bolt: Prevent O(N) re-renders in EdgeList

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-01 - React-Redux useSelector O(N) Re-render Bottleneck
+**Learning:** `useSelector` in React-Redux subscribes the component to any change in the selected state. Selecting an entire map/dictionary (like `state.swapped_nodes.status`) when a component only needs specific items from it causes massive, unnecessary O(N) re-renders across all mounted components whenever *any* item in the map changes.
+**Action:** Always project only the specific, minimal required state out of large maps when using `useSelector`. If projecting an array or object, use `shallowEqual` (imported from `react-redux`) as the second argument to `useSelector` so Redux knows to bail out of re-rendering if the selected values haven't changed.

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -37,6 +37,7 @@ import TopButton from "./TopButton";
 import { TotalTime } from "./TotalTime";
 import * as types from "./types";
 import { useSelector, useDispatch } from "./types";
+import { shallowEqual } from "react-redux";
 
 import * as actions from "./actions";
 import * as consts from "./consts";
@@ -1029,16 +1030,30 @@ const EdgeList = (props: {
   const children = utils.assertV(
     useSelector((state) => state.swapped_nodes.children?.[props.node_id]),
   );
-  const statuses = utils.assertV(
-    useSelector((state) => state.swapped_nodes.status),
+  const edge_ids = React.useMemo(
+    () => ops.sorted_keys_of(children),
+    [children],
   );
-  const cs = utils.assertV(useSelector((state) => state.swapped_edges.c ?? {}));
+  // ⚡ Bolt Optimization: Prevent O(N) re-renders
+  // Previously, EdgeList subscribed to the entire `state.swapped_nodes.status` map.
+  // Any status change in the app would force every EdgeList to re-render.
+  // Now, we project only the specific statuses for this node's children and use
+  // `shallowEqual` so the component only re-renders when a child's status actually changes.
+  const childStatuses = useSelector((state) => {
+    const statuses = state.swapped_nodes.status;
+    const cs = state.swapped_edges.c ?? {};
+    return edge_ids.map((edgeId) => {
+      const c = cs[edgeId];
+      return c ? statuses?.[c] : undefined;
+    });
+  }, shallowEqual);
+
   const todos = Array<JSX.Element>();
   const dones = Array<JSX.Element>();
   const donts = Array<JSX.Element>();
-  for (const edgeId of ops.sorted_keys_of(children)) {
-    const c = cs[edgeId];
-    const status = statuses[c];
+  for (let i = 0; i < edge_ids.length; i++) {
+    const edgeId = edge_ids[i];
+    const status = childStatuses[i];
     if (status === "todo") {
       todos.push(<Edge edge_id={edgeId} key={edgeId} prefix={props.prefix} />);
     } else if (status === "done") {
@@ -1047,7 +1062,6 @@ const EdgeList = (props: {
       donts.push(<Edge edge_id={edgeId} key={edgeId} prefix={props.prefix} />);
     }
   }
-  const edge_ids = ops.sorted_keys_of(children);
   return edge_ids.length ? (
     <ol className="list-outside pl-[4em] content-visibility-auto">
       {todos.concat(dones, donts)}


### PR DESCRIPTION
💡 **What:** Refactored `EdgeList` in `client/src/components.tsx` to use a custom `useSelector` projection with `shallowEqual` from `react-redux` to only extract statuses of its specific `edge_ids`.
🎯 **Why:** The component previously called `useSelector((state) => state.swapped_nodes.status)`, which meant any status change in the entire application forced *every* `EdgeList` to re-render, creating a severe O(N) performance bottleneck.
📊 **Impact:** Reduces re-renders significantly. `EdgeList` now only re-renders when one of its *own* children changes status, drastically improving application performance during status updates (e.g., marking items done).
🔬 **Measurement:** Verify by running the frontend application with React DevTools profiler or by verifying tests pass and no regression was introduced (`cd client && ./scripts/check.sh`).

---
*PR created automatically by Jules for task [6172306696316732727](https://jules.google.com/task/6172306696316732727) started by @kshramt*