### PR TITLE
🎨 Palette: Add accessible label to ShowDetailsButton

### DIFF
--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -108,6 +108,8 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   }, [dispatch, props.node_id]);
   return (
     <button
+      aria-label="Show Details"
+      title="Show Details"
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Added `aria-label="Show Details"` and `title="Show Details"` to the `ShowDetailsButton` component.

### 🎯 Why: The user problem it solves
The `ShowDetailsButton` is an icon-only button (displaying the "more_vert" icon). Without an `aria-label`, screen readers would not announce the button's purpose to visually impaired users. Without a `title` attribute, sighted users hovering over the icon lacked a tooltip to explain the button's function. This change makes the interface more intuitive and accessible.

### 📸 Before/After: Screenshots if visual change
The visual change is the appearance of a native browser tooltip when hovering over the button.

### ♿ Accessibility: Any a11y improvements made
- Added `aria-label="Show Details"` to provide an accessible name for screen readers.
- Added `title="Show Details"` to provide a tooltip for sighted users.

---
*PR created automatically by Jules for task [429282173901475631](https://jules.google.com/task/429282173901475631) started by @kshramt*