### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Missing Axum Default Security Headers
+**Vulnerability:** The `api_v2` Axum application was missing basic HTTP security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+**Learning:** Axum does not set these by default. They must be explicitly configured using middleware like `tower_http::set_header::SetResponseHeaderLayer`.
+**Prevention:** Always ensure standard security headers are applied to the `axum::Router` middleware stack.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -338,7 +339,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +379,36 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn create_app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +416,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = create_app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +426,46 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let app = create_app(std::sync::Arc::new(AppState::new(
+            0,
+            sqlx::postgres::PgPoolOptions::new()
+                .connect_lazy("postgres://postgres:postgres@localhost:5432/postgres")
+                .unwrap(),
+        )));
+
+        let request = Request::builder()
+            .uri("/api/v2/not-found")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(
+            response.headers().get("content-security-policy").unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            response.headers().get("strict-transport-security").unwrap(),
+            "max-age=63072000; includeSubDomains; preload"
+        );
+        assert_eq!(response.headers().get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(
+            response.headers().get("x-content-type-options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            response.headers().get("referrer-policy").unwrap(),
+            "no-referrer"
+        );
+    }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `api_v2` Axum application did not implement common HTTP security headers, leaving it potentially vulnerable to specific clickjacking or injection attacks (although the API mostly returns JSON, enforcing strict browser-level protections is a defense-in-depth best practice).
🎯 Impact: Without headers like HSTS and CSP, clients interacting with the API might fallback to insecure mechanisms or handle content improperly, increasing the attack surface.
🔧 Fix: Used `tower_http::set_header::SetResponseHeaderLayer` to globally apply strict CSP, HSTS, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy headers to the router. The router creation was extracted to a `create_app` function to enable offline unit testing. Added learning to `.jules/sentinel.md`.
✅ Verification: Ran `cargo clippy`, `cargo fmt`, and a newly added `test_security_headers` that spins up the middleware layer offline using `tower::ServiceExt::oneshot`.

---
*PR created automatically by Jules for task [13004543732576221360](https://jules.google.com/task/13004543732576221360) started by @kshramt*