### PR TITLE
⚡ Bolt: [performance improvement] optimize EdgeList re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-20 - Global State Selector Re-render Anti-Pattern
+**Learning:** Using `useSelector` to grab an entire dictionary/map from Redux state (e.g., `useSelector(state => state.swapped_nodes.status)`) in a list component (like `EdgeList`) creates an O(N) global re-render bottleneck. The component will re-render if *any* node's status changes anywhere in the app, not just the ones relevant to the current component.
+**Action:** When a component needs data for multiple specific IDs, memoize the list of IDs (`edge_ids`), then return a mapped array of just those specific values inside `useSelector`, and pass `shallowEqual` as the second argument. This ensures the component only re-renders when its specific dependencies change.

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1029,16 +1029,28 @@ const EdgeList = (props: {
   const children = utils.assertV(
     useSelector((state) => state.swapped_nodes.children?.[props.node_id]),
   );
-  const statuses = utils.assertV(
-    useSelector((state) => state.swapped_nodes.status),
+  const edge_ids = React.useMemo(
+    () => ops.sorted_keys_of(children),
+    [children],
   );
-  const cs = utils.assertV(useSelector((state) => state.swapped_edges.c ?? {}));
+  // OPTIMIZATION: Only select the specific statuses we need for these children.
+  // Mapping statuses and using shallowEqual prevents O(N) global re-renders
+  // when unrelated nodes change status elsewhere in the application.
+  const edgeStatuses = useSelector((state) => {
+    const statuses = state.swapped_nodes.status;
+    const cs = state.swapped_edges.c ?? {};
+    return edge_ids.map((edgeId) => {
+      const c = cs[edgeId];
+      return statuses ? statuses[c] : undefined;
+    });
+  }, Rr.shallowEqual);
+
   const todos = Array<JSX.Element>();
   const dones = Array<JSX.Element>();
   const donts = Array<JSX.Element>();
-  for (const edgeId of ops.sorted_keys_of(children)) {
-    const c = cs[edgeId];
-    const status = statuses[c];
+  for (let i = 0; i < edge_ids.length; i++) {
+    const edgeId = edge_ids[i];
+    const status = edgeStatuses[i];
     if (status === "todo") {
       todos.push(<Edge edge_id={edgeId} key={edgeId} prefix={props.prefix} />);
     } else if (status === "done") {
@@ -1047,7 +1059,6 @@ const EdgeList = (props: {
       donts.push(<Edge edge_id={edgeId} key={edgeId} prefix={props.prefix} />);
     }
   }
-  const edge_ids = ops.sorted_keys_of(children);
   return edge_ids.length ? (
     <ol className="list-outside pl-[4em] content-visibility-auto">
       {todos.concat(dones, donts)}


### PR DESCRIPTION
⚡ Bolt: [performance improvement] optimize EdgeList re-renders

* 💡 What: Replaced mapping over `useSelector` returning entire dictionary objects with mapping array values inside `useSelector` and using `shallowEqual`.
* 🎯 Why: Using `useSelector` to grab the entire `state.swapped_nodes.status` or `state.swapped_edges.c` map caused the component to re-render globally anytime ANY status anywhere changed, creating an O(N) re-render bottleneck.
* 📊 Impact: Prevents global O(N) re-renders, vastly improving performance when lots of items change statuses elsewhere.
* 🔬 Measurement: Observe component updates via React DevTools during status changes.

---
*PR created automatically by Jules for task [16917066557013161234](https://jules.google.com/task/16917066557013161234) started by @kshramt*