### PR TITLE
🎨 Palette: Add aria-label and title to ShowDetailsButton

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-11-20 - Ensure Tooltips and ARIA on All Icon Buttons
+**Learning:** Found an instance (`ShowDetailsButton`) where an icon-only button had the `.btn-icon` class but lacked both `aria-label` and `title` attributes, making it completely invisible/unusable to screen readers and difficult for all users to understand what the "more vert" icon represents.
+**Action:** When adding `.btn-icon` styled buttons that rely purely on `consts.XYZ_MARK` icons without text, ALWAYS add explicit `aria-label` (for screen readers) and `title` (for tooltips on hover). We should perform regular audits of `client/src/` for `<button className="btn-icon">` tags that miss these attributes.

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -108,9 +108,11 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   }, [dispatch, props.node_id]);
   return (
     <button
+      aria-label="Show details"
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
+      title="Show details"
     >
       {consts.DETAIL_MARK}
     </button>


### PR DESCRIPTION
💡 What: Added explicit `aria-label` and `title` attributes to the `ShowDetailsButton` component.
🎯 Why: Icon-only buttons without accessible names are invisible to screen readers, and lacking a title means sighted users don't get a helpful tooltip explaining what the "more vert" icon does.
♿ Accessibility: Improved screen reader support and general usability by providing a clear text alternative ("Show details") for the `ShowDetailsButton`.
📝 Journaled: Recorded learning about ensuring `btn-icon` components always have accessibility attributes in `.jules/palette.md`.

---
*PR created automatically by Jules for task [12534121019776055002](https://jules.google.com/task/12534121019776055002) started by @kshramt*