### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-05 - Missing Security Headers in Backend Service
+**Vulnerability:** The Axum backend application (`api_v2`) does not enforce any HTTP security headers in its middleware stack, and Axum does not provide them by default. This leaves the API vulnerable to Clickjacking, MIME-sniffing, missing HSTS, and lacking a Content-Security-Policy.
+**Learning:** Even if a reverse proxy like Envoy/Nginx is in front of the application or the application only serves JSON APIs, applying defense-in-depth directly at the application level ensures headers are not accidentally bypassed by proxy misconfigurations. The `api_v2` memory context also notes that `tower_http::set_header::SetResponseHeaderLayer` should be used for this.
+**Prevention:** Always add security headers middleware (e.g. `tower_http::set_header`) to axum applications by default.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,7 +391,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Axum backend application (`api_v2`) did not enforce any HTTP security headers in its middleware stack, and Axum does not provide them by default. This leaves the API susceptible to Clickjacking, MIME-sniffing, missing HSTS, and lacking a Content-Security-Policy if the reverse proxy (Envoy/Nginx) misconfiguration occurs.
🎯 **Impact:** Potential bypass of proxy headers leading to basic web vulnerabilities.
🔧 **Fix:** Added `tower_http::set_header::SetResponseHeaderLayer` middleware to the axum router to enforce CSP, HSTS, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy on all responses as a defense-in-depth measure.
✅ **Verification:** Verified by compiling the service, passing `cargo test`, `cargo clippy`, and validating the frontend checks as passing.

---
*PR created automatically by Jules for task [7303504513083452039](https://jules.google.com/task/7303504513083452039) started by @kshramt*