### PR TITLE
🎨 Palette: [UX improvement] Add tooltips and ARIA labels to icon-only buttons

### DIFF
--- a/client/src/Calendar/AddButton.tsx
+++ b/client/src/Calendar/AddButton.tsx
@@ -19,7 +19,12 @@ const AddButton = (props: { timeId: string }) => {
     );
   }, [dispatch, props.timeId, nodeIds]);
   return (
-    <button className="btn-icon" onClick={handleClick}>
+    <button
+      className="btn-icon"
+      onClick={handleClick}
+      aria-label="Add nodes to time node"
+      title="Add nodes to time node"
+    >
       {consts.ADD_MARK}
     </button>
   );

--- a/client/src/TocForm/Component/index.tsx
+++ b/client/src/TocForm/Component/index.tsx
@@ -16,7 +16,12 @@ const TocForm = ({
 }) => {
   return (
     <>
-      <button className="btn-icon" onClick={props.toggleSelected}>
+      <button
+        className="btn-icon"
+        onClick={props.toggleSelected}
+        aria-label="Toggle table of contents"
+        title="Toggle table of contents"
+      >
         {consts.TOC_MARK}
       </button>
       <div className={utils.join(props.selected || "hidden")}>

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -578,7 +578,12 @@ const Timeline = () => {
   return (
     <>
       {decade_nodes}
-      <button className="btn-icon" onClick={increment_count}>
+      <button
+        className="btn-icon"
+        onClick={increment_count}
+        aria-label="Add decade"
+        title="Add decade"
+      >
         {consts.ADD_MARK}
       </button>
     </>
@@ -785,13 +790,23 @@ const TimeNodeEntry = (props: { time_node_id: types.TTimeNodeId }) => {
       />
       {isOn && (
         <div className="flex w-fit gap-x-[0.125em]">
-          <button className="btn-icon" onClick={assign_nodes}>
+          <button
+            className="btn-icon"
+            onClick={assign_nodes}
+            aria-label="Assign nodes"
+            title="Assign nodes"
+          >
             {consts.ADD_MARK}
           </button>
           <CopyDescendantTimeNodesPlannedNodeIdsButton
             time_node_id={props.time_node_id}
           />
-          <button className="btn-icon" onClick={toggle_show_children}>
+          <button
+            className="btn-icon"
+            onClick={toggle_show_children}
+            aria-label="Toggle show children"
+            title="Toggle show children"
+          >
             {time_node === undefined || time_node.show_children === "partial"
               ? consts.IS_PARTIAL_MARK
               : time_node.show_children === "full"
@@ -863,7 +878,12 @@ const PlannedNode = (props: {
             </>
           )}
           <CopyNodeIdButton node_id={props.node_id} />
-          <button className="btn-icon" onClick={unassign_node}>
+          <button
+            className="btn-icon"
+            onClick={unassign_node}
+            aria-label="Unassign node"
+            title="Unassign node"
+          >
             {consts.DELETE_MARK}
           </button>
         </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to multiple icon-only buttons across the frontend components.
🎯 **Why:** To improve accessibility for screen reader users and add helpful hover tooltips for sighted users.
♿ **Accessibility:** Screen readers will now properly announce the purpose of these buttons (e.g., "Add decade", "Assign nodes", "Toggle table of contents") instead of leaving them unlabeled or announcing unhelpful raw ligature text.

---
*PR created automatically by Jules for task [10892499005894681666](https://jules.google.com/task/10892499005894681666) started by @kshramt*