### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to API responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - Axum (v0.7) Missing Default Security Headers
+**Vulnerability:** The API responses lack default security headers.
+**Learning:** Axum (v0.7) does not provide default security headers; they must be explicitly added via middleware layers like `tower_http::set_header::SetResponseHeaderLayer`.
+**Prevention:** Always verify and manually configure security headers when using Axum or similar frameworks that do not set them by default.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,7 +391,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Axum (v0.7) API application lacked default HTTP security headers such as `Content-Security-Policy`, `X-Frame-Options`, and `Strict-Transport-Security`, leaving API responses potentially vulnerable to MIME-sniffing, clickjacking, and side-channel exploits depending on how standard browsers handle direct responses or misconfigured client-side proxy setups.
🎯 Impact: While a pure JSON API without rendered HTML mitigates several typical browser exploits like XSS directly on the API domain, lacking these headers fails defense-in-depth principles and can fail automated security audits. It also exposes the API to MIME-sniffing attacks.
🔧 Fix: Added `tower_http::set_header::SetResponseHeaderLayer` middleware to explicitly inject robust default security headers globally on all Axum routes. Also recorded this pattern in `.jules/sentinel.md`.
✅ Verification: Ran `cargo test` to verify API integrity and `pnpm test` and `pnpm build` in the frontend client to verify no regressions in fullstack proxying.

---
*PR created automatically by Jules for task [12555835654476006498](https://jules.google.com/task/12555835654476006498) started by @kshramt*