### PR TITLE
⚡ Bolt: Add React.memo to list item components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - Memoizing list item components
+**Learning:** React re-renders virtualized list items components like `QueueEntry` or mapped list components like `MobileQueueNode` excessively when the parent state updates, causing O(N) performance issues because they depend only on primitive props (`node_id`, `index`).
+**Action:** Always wrap components rendered in large lists that receive primitive props with `React.memo` to skip unnecessary re-rendering.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,10 +17,10 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+export const QueueEntry = React.memo(function QueueEntry(props: {
   node_id: types.TNodeId;
   index: number;
-}) => {
+}) {
   const exists = useRawSelector((state) =>
     Object.hasOwn(state.data.nodes, props.node_id),
   );
@@ -29,7 +29,7 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,9 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+const MobileQueueNode = React.memo(function MobileQueueNode(props: {
+  nodeId: types.TNodeId;
+}) {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1237,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
# 💡 What
Wrapped the `QueueEntry` and `MobileQueueNode` components inside `React.memo`. 

# 🎯 Why
React inherently re-renders child components whenever the parent's state or props change. By default, even pure presentational components nested inside lists mapped over O(N) array items or handled by react-virtuoso cause global performance regressions. Since these specific components receive minimal, non-complex primitive props, memoization serves as an immediate fix to stop these re-renders.

# 📊 Impact
Reduces list item re-renders from O(N) to roughly O(1) for unchanged items on scroll and generic state updates.

# 🔬 Measurement
This is verifiable by adding arbitrary generic test renders using React Profiler inside Chrome DevTools over a heavily-populated user task tree and scrolling up and down the viewport. Unchanged row nodes will not execute their component function render loops.

---
*PR created automatically by Jules for task [14484935239861720776](https://jules.google.com/task/14484935239861720776) started by @kshramt*