### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-07 - Add missing security headers to Axum backend
+**Vulnerability:** The `api_v2` Axum application was missing basic security headers such as `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`. Axum by default does not add these headers.
+**Learning:** Axum requires developers to explicitly configure security headers using middleware like `tower_http::set_header::SetResponseHeaderLayer`.
+**Prevention:** Always verify headers in Axum and ensure security middleware is added to the application router during initialization.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,7 +391,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
This PR adds missing security headers to the `api_v2` Axum backend application and documents this learning in the Sentinel journal.

🚨 Severity: MEDIUM
💡 Vulnerability: The Axum backend application lacked basic security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
🎯 Impact: Without these headers, the API could be vulnerable to cross-site scripting, clickjacking, or content-type sniffing if responses were unexpectedly rendered in a browser environment.
🔧 Fix: Added explicit configuration for these security headers using `tower_http::set_header::SetResponseHeaderLayer` in the main Axum application router.
✅ Verification: Ran `cargo fmt`, `cargo clippy`, and `cargo test` in `api_v2`. Verified tests passed and no warnings were generated.

Also added `#[allow(dead_code)]` to the auto-generated `gen.rs` import in `main.rs` to satisfy strict CI checks.

---
*PR created automatically by Jules for task [920536054808254877](https://jules.google.com/task/920536054808254877) started by @kshramt*