### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-08 - Adding aria-label and title to icon-only buttons
+**Learning:** Found several icon-only buttons (`MoveUpButton`, `MoveDownButton`, `EvalButton`, `StartConcurrentButton`, `TopButton`) lacking `aria-label` and `title` attributes. Without these attributes, screen readers cannot properly announce the button's purpose, and sighted users do not get native tooltips.
+**Action:** When adding new icon-only buttons, always ensure both `aria-label` (for screen readers) and `title` (for tooltips) are provided.

--- a/client/dev-dist/registerSW.js
+++ b/client/dev-dist/registerSW.js
@@ -1,0 +1,1 @@
+if('serviceWorker' in navigator) navigator.serviceWorker.register('/dev-sw.js?dev-sw', { scope: '/', type: 'classic' })

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -57,6 +57,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move up"
+      title="Move up"
       className="btn-icon"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
@@ -76,6 +78,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move down"
+      title="Move down"
       className="btn-icon"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -14,6 +14,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Evaluate"
+      title="Evaluate"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -14,6 +14,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start concurrently"
+      title="Start concurrently"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -12,6 +12,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Move to top"
+      title="Move to top"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to `EvalButton`, `MoveUpButton`, `MoveDownButton`, `TopButton`, and `StartConcurrentButton` components. Also created `.jules/palette.md` to track UX/accessibility learnings.
🎯 Why: Without these attributes, icon-only buttons are invisible/unclear to screen readers and offer no tooltips on hover for sighted users, leading to a poorer experience.
♿ Accessibility: Improved screen reader navigation by ensuring these buttons have descriptive text, and enhanced general usability with native hover tooltips.

---
*PR created automatically by Jules for task [1533032638419574241](https://jules.google.com/task/1533032638419574241) started by @kshramt*