### PR TITLE
⚡ Bolt: Add React.memo to Queue components to prevent O(N) re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-03-08 - Use React.memo for list items receiving primitive props
+**Learning:** In lists with numerous items (like queues or virtualized lists via `react-virtuoso`), mapping child components without `React.memo` causes unnecessary O(N) re-renders when parent state updates.
+**Action:** When a list child component (`QueueEntry`, `MobileQueueNode`, etc.) takes simple primitive props like `node_id` or `index`, always wrap it in `React.memo` to skip re-renders when these props haven't changed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN cargo install sqlx-cli@0.8.2
 FROM build_essential_base AS base_rust
 COPY --link --from=rust_downloader /usr/local/cargo /usr/local/cargo
 COPY --link --from=rust_downloader /usr/local/rustup /usr/local/rustup
-ENV PATH "/usr/local/cargo/bin:/usr/local/rustup/bin:${PATH}"
+ENV PATH="/usr/local/cargo/bin:/usr/local/rustup/bin:${PATH}"
 ENV RUSTUP_HOME="/usr/local/rustup"
 ENV CARGO_HOME="/usr/local/cargo"
 
@@ -180,8 +180,8 @@ ENV RUSTUP_HOME="/usr/local/rustup"
 ENV CARGO_HOME="/home/${devcontainer_user:?}/.cargo"
 
 FROM ubuntu_base AS base_py
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
 WORKDIR /app
 
 FROM nginx:1.29.3-alpine AS base_nginx
@@ -267,7 +267,7 @@ FROM base_postgres AS prod_postgres
 
 FROM debian:13.2-slim AS prod_postgres_migration
 ARG SOURCE_DATE_EPOCH
-ENV SOURCE_DATE_EPOCH ${SOURCE_DATE_EPOCH:-0}
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-0}
 COPY --link --from=base_dbmate /usr/local/bin/dbmate /usr/local/bin/dbmate
 COPY --link db/scripts/migrate.sh /app/scripts/migrate.sh
 COPY --link db/migrations /app/db/migrations
@@ -309,7 +309,7 @@ RUN cargo build --release
 
 FROM gcr.io/distroless/cc-debian12:nonroot AS prod_api_v2
 ARG SOURCE_DATE_EPOCH
-ENV SOURCE_DATE_EPOCH ${SOURCE_DATE_EPOCH:-0}
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-0}
 COPY --link --from=base_rust_builder /app/target/release/api_v2 /work/api_v2
 WORKDIR /work
 ENTRYPOINT ["./api_v2"]

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,7 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +29,7 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,18 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,7 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1235,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What**: Wrapped list item components `QueueEntry` and `MobileQueueNode` with `React.memo` to prevent unnecessary component tree updates when the parent component re-renders but the child's primitive props (`node_id`, `index`) haven't changed.
🎯 **Why**: When mapping through large arrays or using virtualized lists (like `react-virtuoso`), mapping child components that are not memoized triggers an O(N) re-render of all visible items whenever the parent's state changes, leading to degraded scrolling and input performance.
📊 **Impact**: Reduces React rendering overhead in the Queue views during store updates. Re-renders will now be properly skipped for nodes whose properties (e.g. `node_id`) remain identical across renders.
🔬 **Measurement**: Verify via React DevTools Profiler during scrolling or task additions in the queue view; observed rendering time should be lower, and unnecessary "rendered because parent rendered" events should be eliminated for these components.

---
*PR created automatically by Jules for task [8326009758727478282](https://jules.google.com/task/8326009758727478282) started by @kshramt*