### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing security headers

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,3 +1,10 @@
+use axum::http::{
+    header::{
+        CONTENT_SECURITY_POLICY, REFERRER_POLICY, STRICT_TRANSPORT_SECURITY,
+        X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS,
+    },
+    HeaderValue,
+};
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
     http::request::Parts,
@@ -13,11 +20,13 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,6 +399,26 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(SetResponseHeaderLayer::overriding(
+            CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            REFERRER_POLICY,
+            HeaderValue::from_static("no-referrer"),
+        ))
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 
     let port = get_server_port();


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The Axum backend API server lacked default security HTTP response headers. 
🎯 **Impact:** Exposes the API and application to security risks such as clickjacking, MIME-type sniffing, XSS, and unencrypted transmission on subsequent requests.
🔧 **Fix:** Integrated `tower_http::set_header::SetResponseHeaderLayer` to automatically inject `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`.
✅ **Verification:** Run `cargo test` and `cargo clippy`. Ensure the application continues to compile and execute properly while injecting headers.

---
*PR created automatically by Jules for task [5253128188942181520](https://jules.google.com/task/5253128188942181520) started by @kshramt*