### PR TITLE
⚡ Bolt: [performance improvement] Prevent O(N) re-renders in virtualized lists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Prevent O(N) Re-Renders in Virtualized/Mapped Lists
+**Learning:** List item components in virtualized lists (like `react-virtuoso`) or large mapped arrays that receive primitive props (e.g., `node_id`, `index`) can cause unnecessary O(N) re-renders during scrolling and state updates. This can lead to noticeable scroll lag or delays when interacting with elements.
+**Action:** Always wrap such list item components (e.g., `QueueEntry`, `MobileQueueNode`) in `React.memo` to skip re-rendering if their props haven't changed.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,18 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,7 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1235,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Prevent O(N) re-renders in virtualized lists

💡 What:
Wrapped `QueueEntry` (in `client/src/QueueEntry.tsx`) and `MobileQueueNode` (in `client/src/components.tsx`) in `React.memo`.

🎯 Why:
These components are list items rendered within large virtualized lists (`react-virtuoso`) or mapped arrays and receive primitive props (`node_id`, `index`, `nodeId`). Without memoization, any parent state change causes unnecessary O(N) re-renders across the entire list, leading to scroll lag and delayed interaction.

📊 Impact:
Reduces list item re-renders by skipping reconciliation when props (primitives) haven't changed.

🔬 Measurement:
Run React Developer Tools Profiler and perform actions that cause parent re-renders (e.g. typing in inputs). `QueueEntry` and `MobileQueueNode` will no longer unnecessarily render.

Also added a journal entry in `.jules/bolt.md` documenting this React performance anti-pattern.

---
*PR created automatically by Jules for task [1403893426856037544](https://jules.google.com/task/1403893426856037544) started by @kshramt*