### PR TITLE
⚡ Bolt: [performance improvement] Add React.memo to list item components

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,18 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,7 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1235,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What:** Wrapped `QueueEntry` and `MobileQueueNode` components with `React.memo()`.

🎯 **Why:** Both components are rendered within lists (`react-virtuoso` and mapped arrays) and receive primitive props (`node_id`, `index`). Without `React.memo`, these items will re-render unnecessarily on global state changes or during heavy virtualized scrolling, which impacts responsiveness and wastes CPU cycles.

📊 **Impact:** Reduces unneeded child component tree reconciliation/re-renders for un-mutated list items (essentially reducing work from O(N) to O(1) for unaffected nodes), significantly improving performance of large lists, especially on mobile.

🔬 **Measurement:** Verify by running `pnpm dev` in the client, logging component renders to the console (e.g. using React Developer Tools Profiler), and triggering an action (like copying a node ID or toggling start/stop). Only the affected nodes should re-render now. Checked via `pnpm lint` and formatting pipelines.

---
*PR created automatically by Jules for task [7689121457198364346](https://jules.google.com/task/7689121457198364346) started by @kshramt*