### PR TITLE
🎨 Palette: Add aria-hidden to Material Icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-11 - Add aria-hidden to Material Icons inside interactive elements
+**Learning:** Material UI icon spans (e.g., `<span className="material-icons">`) must include `aria-hidden="true"` to prevent screen readers from incorrectly announcing their ligature text (e.g., "close", "play_arrow"), ensuring parent elements (like buttons) dictate the accessible name.
+**Action:** Always add `aria-hidden="true"` to ligature-based icon spans, especially when used inside buttons where the button itself provides the `aria-label` or `title`.

--- a/client/src/Header/MenuButton/index.tsx
+++ b/client/src/Header/MenuButton/index.tsx
@@ -50,7 +50,9 @@ const MenuButton = (props: {
           onClick={handleButtonClick}
           className="btn-icon"
         >
-          <span className="material-icons">menu</span>
+          <span className="material-icons" aria-hidden="true">
+            menu
+          </span>
         </button>
       </Menu.Target>
 

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -48,11 +48,15 @@ import * as ops from "./ops";
 import * as undoable from "./undoable";
 
 const SCROLL_BACK_TO_TOP_MARK = (
-  <span className="material-icons">vertical_align_top</span>
+  <span className="material-icons" aria-hidden="true">
+    vertical_align_top
+  </span>
 );
 
 const SCROLL_BACK_TO_BOTTOM_MARK = (
-  <span className="material-icons">vertical_align_bottom</span>
+  <span className="material-icons" aria-hidden="true">
+    vertical_align_bottom
+  </span>
 );
 
 const nonTodoQueueNodesRef = React.createRef<Rv.VirtuosoHandle>();
@@ -442,7 +446,9 @@ const Menu = (props: {
         onClick={_redo}
         onDoubleClick={prevent_propagation}
       >
-        <span className="material-icons">redo</span>
+        <span className="material-icons" aria-hidden="true">
+          redo
+        </span>
       </button>
       <Mt.Switch
         checked={sortByCtime}
@@ -1150,7 +1156,9 @@ const MobileMenu = (props: {
         onClick={_redo}
         onDoubleClick={prevent_propagation}
       >
-        <span className="material-icons">redo</span>
+        <span className="material-icons" aria-hidden="true">
+          redo
+        </span>
       </button>
       <Mt.Switch
         checked={show_todo_only}

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -4,40 +4,128 @@ export const MINUTE = 60 * 1_000;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
 
-export const DELETE_MARK = <span className="material-icons">close</span>;
+export const DELETE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    close
+  </span>
+);
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
+export const START_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    play_arrow
+  </span>
+);
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons">double_arrow</span>
+  <span className="material-icons" aria-hidden="true">
+    double_arrow
+  </span>
 );
-export const ADD_MARK = <span className="material-icons">add</span>;
-export const DONE_MARK = <span className="material-icons">done</span>;
-export const DONT_MARK = <span className="material-icons">delete</span>;
-export const DETAIL_MARK = <span className="material-icons">more_vert</span>;
-export const COPY_MARK = <span className="material-icons">content_copy</span>;
-export const STOP_MARK = <span className="material-icons">stop</span>;
-export const TOP_MARK = <span className="material-icons">arrow_upward</span>;
-export const UNDO_MARK = <span className="material-icons">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons">south</span>;
-export const EVAL_MARK = <span className="material-icons">functions</span>;
-export const TOC_MARK = <span className="material-icons">toc</span>;
+export const ADD_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    add
+  </span>
+);
+export const DONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    done
+  </span>
+);
+export const DONT_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    delete
+  </span>
+);
+export const DETAIL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    more_vert
+  </span>
+);
+export const COPY_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_copy
+  </span>
+);
+export const STOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    stop
+  </span>
+);
+export const TOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_upward
+  </span>
+);
+export const UNDO_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    undo
+  </span>
+);
+export const MOVE_UP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    north
+  </span>
+);
+export const MOVE_DOWN_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    south
+  </span>
+);
+export const EVAL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    functions
+  </span>
+);
+export const TOC_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    toc
+  </span>
+);
 export const FORWARD_MARK = (
-  <span className="material-icons">arrow_forward_ios</span>
+  <span className="material-icons" aria-hidden="true">
+    arrow_forward_ios
+  </span>
 );
-export const BACK_MARK = <span className="material-icons">arrow_back_ios</span>;
-export const SEARCH_MARK = <span className="material-icons">search</span>;
-export const IDS_MARK = <span className="material-icons">content_paste</span>;
-export const MOBILE_MARK = <span className="material-icons">smartphone</span>;
+export const BACK_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_back_ios
+  </span>
+);
+export const SEARCH_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    search
+  </span>
+);
+export const IDS_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_paste
+  </span>
+);
+export const MOBILE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    smartphone
+  </span>
+);
 export const DESKTOP_MARK = (
-  <span className="material-icons">desktop_windows</span>
+  <span className="material-icons" aria-hidden="true">
+    desktop_windows
+  </span>
 );
-export const IS_FULL_MARK = <span className="material-icons">expand_more</span>;
-export const IS_NONE_MARK = <span className="material-icons">expand_less</span>;
+export const IS_FULL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_more
+  </span>
+);
+export const IS_NONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_less
+  </span>
+);
 export const IS_PARTIAL_MARK = (
-  <span className="material-icons">chevron_right</span>
+  <span className="material-icons" aria-hidden="true">
+    chevron_right
+  </span>
 );
 
 export const SPINNER = (


### PR DESCRIPTION
💡 **What**: Added `aria-hidden="true"` to `<span className="material-icons">` icon spans across `consts.tsx`, `components.tsx`, and `MenuButton/index.tsx`.
🎯 **Why**: When ligature-based fonts are used for icons, screen readers may announce the ligature string (e.g. "play_arrow", "close", "menu"), which creates a poor accessibility experience. Adding `aria-hidden="true"` hides these decorative/presentational spans from screen readers, allowing the parent elements (buttons) to correctly dictate the accessible name via `aria-label` or `title`.
♿ **Accessibility**: Prevents redundant or incorrect screen reader announcements for icon ligatures across the entire application interface.

---
*PR created automatically by Jules for task [766913542329285598](https://jules.google.com/task/766913542329285598) started by @kshramt*