### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/Cargo.toml
+++ b/api_v2/Cargo.toml
@@ -19,6 +19,6 @@ serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "macros", "uuid", "chrono", "json"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["full"] }
+tower-http = { version = "0.6", features = ["full", "set-header"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing security headers (CSP, X-Frame-Options, HSTS, etc.) on API responses. Axum does not include any security headers by default.
🎯 Impact: Without security headers, the API is more vulnerable to attacks like Cross-Site Scripting (XSS), Clickjacking, MIME-type sniffing, and man-in-the-middle attacks (if HSTS is absent).
🔧 Fix: Added multiple `SetResponseHeaderLayer` layers to the global Axum Router in `api_v2/src/main.rs`. We set `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; sandbox`, `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: no-referrer`.
✅ Verification: Ran `cargo test`, `cargo clippy`, and `cargo fmt` to verify functionality, code formatting and styling within the `api_v2` project.

---
*PR created automatically by Jules for task [13377601237811963670](https://jules.google.com/task/13377601237811963670) started by @kshramt*