### PR TITLE
🛡️ Sentinel: [HIGH] Fix Missing Security Headers in API

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
-    http::request::Parts,
+    http::{header, request::Parts, HeaderValue},
     Json, RequestPartsExt,
 };
 use axum_extra::{
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -389,6 +390,26 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::REFERRER_POLICY,
+            HeaderValue::from_static("no-referrer"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Missing default security headers in the `api_v2` Axum server. This could expose the application API to attacks such as XSS, framing (Clickjacking), or MIME-type sniffing.
🎯 **Impact:** If exploited, attackers could use the API endpoint for framing, sniffing responses, or failing to enforce HTTPS properly, leading to increased risk of credential or data theft.
🔧 **Fix:** Implemented `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs` to enforce CSP, HSTS, X-Frame-Options (DENY), X-Content-Type-Options (nosniff), and Referrer-Policy (no-referrer).
✅ **Verification:** Run `cargo test`, `cargo clippy`, and `cargo fmt` to verify that the middleware is correctly applied and compile-time checks pass.

---
*PR created automatically by Jules for task [15037260058864598999](https://jules.google.com/task/15037260058864598999) started by @kshramt*