### PR TITLE
⚡ Bolt: Add React.memo to list items to prevent O(N) re-renders

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,22 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt Performance Optimization:
+// Wrapped QueueEntry in React.memo to prevent O(N) re-renders during scrolling and state updates.
+// QueueEntry receives primitive props (node_id, index) making it an ideal candidate for memoization,
+// especially since it's rendered inside a react-virtuoso virtualized list.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,11 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+// ⚡ Bolt Performance Optimization:
+// Wrapped MobileQueueNode in React.memo to prevent O(N) re-renders when parent state updates.
+// Since it receives primitive props (nodeId), memoization ensures efficient rendering
+// within mapped arrays in the mobile view.
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1239,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What**: Added `React.memo` wrappers around `QueueEntry` and `MobileQueueNode`.
🎯 **Why**: Both components are part of potentially large lists (`react-virtuoso` for desktop, mapped array for mobile). Since they only receive primitive props (IDs/indexes), adding `React.memo` effectively caches the components and prevents O(N) re-renders globally whenever unrelated state updates or scroll events occur. 
📊 **Impact**: Reduces list item re-renders by near 100% when parent state objects shift without altering the specific item props.
🔬 **Measurement**: Verify by using React DevTools Profiler to check render times when toggling UI elements globally or interacting with single items—siblings will no longer aggressively re-render.

---
*PR created automatically by Jules for task [9103110678139607775](https://jules.google.com/task/9103110678139607775) started by @kshramt*