### PR TITLE
⚡ Bolt: [performance improvement] Optimize list item re-renders with React.memo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-15 - Prevent Unnecessary O(N) Re-renders in Large Lists
+**Learning:** List item components receiving primitive props (like `node_id` and `index`) within `react-virtuoso` virtualized lists or mapped arrays (e.g., `QueueEntry`, `MobileQueueNode`) will still cause O(N) re-renders during scrolling and state updates if they are not explicitly memoized.
+**Action:** Always wrap primitive-prop-receiving list item components in `React.memo` (especially those inside virtualized lists or large array maps) to ensure optimal performance and avoid unnecessary O(N) global render cycles.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,19 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: Wrapped in React.memo to prevent O(N) re-renders during scrolling and state updates within react-virtuoso
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+// ⚡ Bolt: Wrapped in React.memo to prevent O(N) re-renders during state updates in large mapped arrays
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What:**
Wrapped `QueueEntry` and `MobileQueueNode` components in `React.memo`.

🎯 **Why:**
These components are rendered repeatedly within `react-virtuoso` virtualized lists or large mapped arrays. They only receive primitive props (like `node_id` and `index`), but without memoization, any state update or scroll event in the parent list component forces all child items to unnecessarily re-render, creating an O(N) performance bottleneck.

📊 **Impact:**
Significantly reduces React render cycles. O(N) re-renders for list items are effectively reduced to O(1) or limited only to items whose specific `node_id` or `index` actually changed, vastly improving scroll performance and UI responsiveness during state updates.

🔬 **Measurement:**
This can be verified using the React Profiler. Prior to this change, modifying global state or scrolling rapidly would show a large number of `QueueEntry` components re-rendering. After this change, the Profiler will show that these components skip rendering (grayed out) unless their specific props change.

---
*PR created automatically by Jules for task [16659053112954179071](https://jules.google.com/task/16659053112954179071) started by @kshramt*