### PR TITLE
⚡ Bolt: [performance improvement] Wrap virtualized list items in React.memo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - React.memo for Virtualized List Items
+**Learning:** List item components in React (like `QueueEntry` or `MobileQueueNode`) receiving primitive props like `node_id` and `index` can cause unnecessary O(N) re-renders during scrolling and state updates when used inside virtualized lists like `react-virtuoso` or mapped arrays.
+**Action:** Always wrap such list item components in `React.memo` to prevent global re-renders when only a few items actually change.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: Wrapped QueueEntry in React.memo() to prevent unnecessary O(N) re-renders
+// during scrolling and state updates within react-virtuoso virtualized lists.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,9 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+// ⚡ Bolt: Wrapped MobileQueueNode in React.memo() to prevent unnecessary
+// re-renders during scrolling and state updates within mapped arrays.
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1237,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` and `MobileQueueNode` components in `React.memo()`.
🎯 Why: These list items receive primitive props (`node_id` and `index`) but are rendered inside virtualized lists (`react-virtuoso`) or mapped arrays. Without memoization, they re-render unnecessarily O(N) times during parent scrolling or state updates.
📊 Impact: Prevents global re-renders for unchanged list items, improving scrolling performance and rendering efficiency.
🔬 Measurement: Verified by ensuring UI tests pass, and documented the learning in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [18201971761436568848](https://jules.google.com/task/18201971761436568848) started by @kshramt*