### PR TITLE
⚡ Bolt: [performance improvement] Prevent O(N) re-renders for Queue Entries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-11-20 - React.memo for List Items
+**Learning:** List item components receiving primitive props like `node_id` and `index` (e.g., `QueueEntry`, `MobileQueueNode`) can cause unnecessary O(N) global re-renders during scrolling and state updates within virtualized lists (like `react-virtuoso`) or standard mapped arrays.
+**Action:** Always wrap these pure list item components with `React.memo` to prevent re-renders when their primitive props haven't changed.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: Prevent O(N) re-renders in virtualized lists by memoizing this pure component.
+// Props are primitives (node_id, index), so shallow comparison is perfect here.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,9 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+// ⚡ Bolt: Prevent O(N) re-renders in mapped arrays by memoizing this pure component.
+// Props are primitives (nodeId), so shallow comparison prevents unnecessary re-renders.
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1237,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
This PR introduces a crucial but straightforward performance fix to the app's list components (`QueueEntry` and `MobileQueueNode`).

💡 What: The optimization wraps both `QueueEntry` and `MobileQueueNode` with `React.memo`.
🎯 Why: These list items receive strictly primitive props (e.g. `node_id`, `index`). Without `React.memo`, any global state update or re-render triggered in the virtualized parent causes an O(N) cascade, unnecessarily re-rendering these items.
📊 Impact: Dramatically reduces component re-renders during scrolling and unrelated user interactions.
🔬 Measurement: Can be verified with the React DevTools Profiler (record a scroll or state update, observe fewer render operations on the list items).

A learning log was also added to `.jules/bolt.md` to establish this rule for future components.

---
*PR created automatically by Jules for task [17348638147755827216](https://jules.google.com/task/17348638147755827216) started by @kshramt*