### PR TITLE
⚡ Bolt: Add React.memo to virtualized list items to prevent O(N) re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - React.memo on Virtualized List Items
+**Learning:** The application heavily utilizes `react-virtuoso` and large mapped arrays (like queues) which receive primitive props such as `node_id` and `index`. Omitting `React.memo` on these list item components (`QueueEntry`, `MobileQueueNode`) causes expensive O(N) re-renders across the entire list during scroll events and state updates in `useSelector`.
+**Action:** Always wrap list item components receiving primitive props in `React.memo`, especially when they are rendered inside virtualized lists or large mapped arrays.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,19 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: Wrapped QueueEntry in React.memo to prevent O(N) re-renders in virtualized lists when queue state changes
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+// ⚡ Bolt: Wrapped MobileQueueNode in React.memo to prevent O(N) re-renders during state updates and mapping
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` and `MobileQueueNode` components in `React.memo()`.

🎯 Why: These list items receive only primitive props (`node_id`, `index`) and are rendered inside large mapped arrays and `react-virtuoso` virtualized lists. Without `React.memo`, any global state change or parent re-render (e.g., during scrolling or `useSelector` updates) causes an expensive O(N) re-render cascade across all visible (and sometimes non-visible) list elements.

📊 Impact: Reduces unnecessary component re-renders for list items to O(1) when global queue state changes or other non-relevant data updates. Substantially improves scrolling smoothness and dispatch performance when updating a single list element.

🔬 Measurement: Verify by interacting with a populated queue in the React Profiler. Toggling an item or dispatching an action should show only the specific item re-rendering, whereas previously the entire virtualized list would re-render.

---
*PR created automatically by Jules for task [15478294629471494910](https://jules.google.com/task/15478294629471494910) started by @kshramt*