### PR TITLE
🎨 Palette: [a11y] Add aria-label and title to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-18 - Missing ARIA Labels and Tooltips on Icon-only Buttons
+**Learning:** Many icon-only `.btn-icon` buttons in this app lack explicit accessible labels (`aria-label`) and tooltips (`title`), making them difficult to understand for both screen reader users and sighted users.
+**Action:** Ensure every `btn-icon` or icon-only button includes both an `aria-label` for screen readers and a `title` attribute for native browser tooltips.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,8 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      title="Add"
+      aria-label="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/Calendar/AddButton.tsx
+++ b/client/src/Calendar/AddButton.tsx
@@ -19,7 +19,12 @@ const AddButton = (props: { timeId: string }) => {
     );
   }, [dispatch, props.timeId, nodeIds]);
   return (
-    <button className="btn-icon" onClick={handleClick}>
+    <button
+      className="btn-icon"
+      title="Add Calendar Event"
+      aria-label="Add Calendar Event"
+      onClick={handleClick}
+    >
       {consts.ADD_MARK}
     </button>
   );

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Copy Node ID"
+      aria-label="Copy Node ID"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Undo to Todo"
+      aria-label="Undo to Todo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EdgeRow/index.tsx
+++ b/client/src/EdgeRow/index.tsx
@@ -67,6 +67,8 @@ const EdgeRow = (props: { edge_id: types.TEdgeId; target: "p" | "c" }) => {
       <td className="p-[0.25em]">
         <button
           className="btn-icon"
+          title="Edge Row Option"
+          aria-label="Edge Row Option"
           onClick={delete_edge}
           onDoubleClick={utils.prevent_propagation}
         >

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Move"
+      aria-label="Move"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +79,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Move"
+      aria-label="Move"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -15,6 +15,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Evaluate"
+      aria-label="Evaluate"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -75,6 +75,8 @@ const Details = (props: { node_id: types.TNodeId }) => {
         </select>
         <button
           className="btn-icon"
+          title="Show Details"
+          aria-label="Show Details"
           onClick={handle_add_parents}
           onDoubleClick={utils.prevent_propagation}
         >
@@ -82,6 +84,8 @@ const Details = (props: { node_id: types.TNodeId }) => {
         </button>
         <button
           className="btn-icon"
+          title="Show Details"
+          aria-label="Show Details"
           onClick={handle_add_children}
           onDoubleClick={utils.prevent_propagation}
         >
@@ -109,6 +113,8 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Show Details"
+      aria-label="Show Details"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Start"
+      aria-label="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Start Concurrent"
+      aria-label="Start Concurrent"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TocForm/Component/index.tsx
+++ b/client/src/TocForm/Component/index.tsx
@@ -16,7 +16,12 @@ const TocForm = ({
 }) => {
   return (
     <>
-      <button className="btn-icon" onClick={props.toggleSelected}>
+      <button
+        className="btn-icon"
+        title="Toggle TOC"
+        aria-label="Toggle TOC"
+        onClick={props.toggleSelected}
+      >
         {consts.TOC_MARK}
       </button>
       <div className={utils.join(props.selected || "hidden")}>
@@ -24,6 +29,8 @@ const TocForm = ({
           onClick={props.onClick}
           onDoubleClick={utils.prevent_propagation}
           className="btn-icon"
+          title="Toggle TOC"
+          aria-label="Toggle TOC"
         >
           Parse
         </button>

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Mark as Done"
+      aria-label="Mark as Done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Mark as Don't"
+      aria-label="Mark as Don't"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TogglePinButton/index.tsx
+++ b/client/src/TogglePinButton/index.tsx
@@ -16,6 +16,8 @@ const TogglePinButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Toggle Pin"
+      aria-label="Toggle Pin"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      title="Top"
+      aria-label="Top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}

--- a/client/src/swapper.ts
+++ b/client/src/swapper.ts
@@ -1,9 +1,8 @@
 export type TSwapped<K1 extends PropertyKey, Data> = Partial<{
   [k2 in keyof Data]: { [k1 in K1]: Data[k2] };
 }>;
-export type TSwapped1<R> = R extends Record<infer K1, infer Data>
-  ? TSwapped<K1, Data>
-  : never;
+export type TSwapped1<R> =
+  R extends Record<infer K1, infer Data> ? TSwapped<K1, Data> : never;
 
 export const add = <K1 extends PropertyKey, Data extends object>(
   x: Record<K1, Data>,

--- a/client/src/swapper.ts
+++ b/client/src/swapper.ts
@@ -1,8 +1,9 @@
 export type TSwapped<K1 extends PropertyKey, Data> = Partial<{
   [k2 in keyof Data]: { [k1 in K1]: Data[k2] };
 }>;
-export type TSwapped1<R> =
-  R extends Record<infer K1, infer Data> ? TSwapped<K1, Data> : never;
+export type TSwapped1<R> = R extends Record<infer K1, infer Data>
+  ? TSwapped<K1, Data>
+  : never;
 
 export const add = <K1 extends PropertyKey, Data extends object>(
   x: Record<K1, Data>,

--- a/modify_buttons.py
+++ b/modify_buttons.py
@@ -1,0 +1,65 @@
+import re
+import os
+
+files_to_modify = [
+    "client/src/AddButton.tsx",
+    "client/src/StartButton/index.tsx",
+    "client/src/TopButton/index.tsx",
+    "client/src/TodoToDoneButton.tsx",
+    "client/src/EvalButton.tsx",
+    "client/src/TodoToDontButton.tsx",
+    "client/src/ShowDetailsButton/index.tsx",
+    "client/src/DoneOrDontToTodoButton.tsx",
+    "client/src/StartConcurrentButton/index.tsx",
+    "client/src/TogglePinButton/index.tsx",
+    "client/src/StopButton/index.tsx",
+    "client/src/CopyNodeIdButton/index.tsx",
+    "client/src/Calendar/AddButton.tsx",
+    "client/src/TocForm/Component/index.tsx",
+    "client/src/EdgeRow/index.tsx",
+    "client/src/EntryButtons.tsx"
+]
+
+mapping = {
+    "client/src/AddButton.tsx": "Add",
+    "client/src/StartButton/index.tsx": "Start",
+    "client/src/TopButton/index.tsx": "Top",
+    "client/src/TodoToDoneButton.tsx": "Mark as Done",
+    "client/src/EvalButton.tsx": "Evaluate",
+    "client/src/TodoToDontButton.tsx": "Mark as Don't",
+    "client/src/ShowDetailsButton/index.tsx": "Show Details",
+    "client/src/DoneOrDontToTodoButton.tsx": "Undo to Todo",
+    "client/src/StartConcurrentButton/index.tsx": "Start Concurrent",
+    "client/src/TogglePinButton/index.tsx": "Toggle Pin",
+    "client/src/StopButton/index.tsx": "Stop",
+    "client/src/CopyNodeIdButton/index.tsx": "Copy Node ID",
+    "client/src/Calendar/AddButton.tsx": "Add Calendar Event",
+    "client/src/TocForm/Component/index.tsx": "Toggle TOC",
+    "client/src/EdgeRow/index.tsx": "Edge Row Option",
+    "client/src/EntryButtons.tsx": "Move"
+}
+
+for file in files_to_modify:
+    if not os.path.exists(file):
+        continue
+    with open(file, "r") as f:
+        content = f.read()
+
+    label = mapping[file]
+
+    def repl(m):
+        full_match = m.group(0)
+        if "aria-label" in full_match or "title" in full_match:
+            return full_match
+        return f'{m.group(1)}className="btn-icon" title="{label}" aria-label="{label}"{m.group(3)}'
+
+    new_content = re.sub(
+        r'(<button[^>]*?)(className="btn-icon")([^>]*?>)',
+        repl,
+        content
+    )
+
+    with open(file, "w") as f:
+        f.write(new_content)
+
+print("Done modifying buttons")


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to `.btn-icon` components.
🎯 Why: To improve accessibility for screen readers and provide hover tooltips for visual users, as icon-only buttons lacked explicit descriptions.
♿ Accessibility: Improved screen reader navigation and descriptive context for icon buttons. Updated `.jules/palette.md` with action steps.

---
*PR created automatically by Jules for task [17756457341515762971](https://jules.google.com/task/17756457341515762971) started by @kshramt*