### PR TITLE
🛡️ Sentinel: [security improvement] Add missing security headers

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::HeaderName::from_static("referrer-policy"),
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers on API responses, making it potentially vulnerable to MIME sniffing, clickjacking, and XSS.
🎯 Impact: Attackers could potentially exploit missing headers if they can embed the API in an iframe or if a browser misinterprets a response payload.
🔧 Fix: Implemented `tower_http::set_header::SetResponseHeaderLayer` to inject standard security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) into all Axum responses.
✅ Verification: Ensure the backend compiles, passes all unit tests, and formats correctly (`cargo check`, `cargo test`, `cargo clippy`, `cargo fmt`).

---
*PR created automatically by Jules for task [18286924274422759882](https://jules.google.com/task/18286924274422759882) started by @kshramt*