### PR TITLE
⚡ Bolt: [performance] Memoize QueueEntry and MobileQueueNode

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,19 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: Add React.memo to prevent unnecessary O(N) re-renders during scrolling and state updates within virtualized lists.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+// ⚡ Bolt: Add React.memo to prevent unnecessary O(N) re-renders during state updates within mapped arrays.
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
⚡ Bolt: [performance] Memoize QueueEntry and MobileQueueNode

💡 What: Wrapped `QueueEntry` and `MobileQueueNode` in `React.memo()`.
🎯 Why: Prevents unnecessary O(N) re-renders during state updates and scrolling within mapped arrays and virtualized lists, as these components frequently render many instances.
📊 Impact: Significantly reduces React re-rendering overhead for list items when parent lists update, leading to smoother scrolling and faster state updates.
🔬 Measurement: Verify by profiling React render times before and after making bulk updates to the queue or scrolling quickly.

---
*PR created automatically by Jules for task [7257187187525027473](https://jules.google.com/task/7257187187525027473) started by @kshramt*