### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to api_v2

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-20 - Missing API Security Headers
+**Vulnerability:** The `api_v2` backend service, which serves `/api/v2/*` endpoints directly without full reliance on Nginx's HTML-specific header rules, was missing defense-in-depth security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+**Learning:** In axum, `tower_http::set_header::SetResponseHeaderLayer` is necessary for establishing security header boundaries when a reverse proxy like Nginx isn't applying them globally or universally (e.g. Nginx was configured to only apply CSP to text/html). Strict CSP (`default-src 'none'`) is highly appropriate for JSON APIs to mitigate potential XSS if responses are inadvertently rendered as HTML by a client.
+**Prevention:** Ensure API backends have their own explicitly defined security headers using `tower-http` to avoid relying entirely on an ingress reverse proxy, creating a defense-in-depth approach.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,7 +391,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `api_v2` backend service, which directly serves `/api/v2/*` endpoints, lacked defense-in-depth security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy). While Nginx handled HTML responses, raw JSON responses returned by the API were exposed to vulnerabilities like MIME-sniffing and unintentional execution/framing.
🎯 **Impact:** Potential for MIME-sniffing, XSS if responses are inadvertently rendered as HTML, and clickjacking attacks if clients misinterpret the API responses.
🔧 **Fix:** Utilized `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs` to explicitly enforce strict security boundaries (`default-src 'none'`) directly at the application layer.
✅ **Verification:** Validated backend logic via `cargo test`, `cargo clippy`, and `cargo fmt`. Verified headers via diff review. Checked frontend logic via `make check`. Recorded learnings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2113173533941192829](https://jules.google.com/task/2113173533941192829) started by @kshramt*