### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and tooltips to icon-only action buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add"
+      title="Add"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -25,6 +25,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Copy Node ID"
+      title={is_copied ? "Copied" : "Copy Node ID (Ctrl+Click to append)"}
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move Up"
+      title="Move Up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move Down"
+      title="Move Down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start Concurrent"
+      title="Start Concurrent"
     >
       {consts.START_CONCURRNET_MARK}
     </button>


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `title` attributes to multiple icon-only buttons across the frontend components (`StartButton`, `StartConcurrentButton`, `AddButton`, `CopyNodeIdButton`, `MoveUpButton`, `MoveDownButton`).
🎯 **Why**: These icon-only buttons (like the `+` icon for Add, `^` for Move Up, or `>` for Start) lacked context for both screen reader users (who would only hear "button" or the generic span content) and mouse users (who had no tooltip explaining the icon's action). This small UX addition makes the interface significantly more accessible and intuitive.
♿ **Accessibility**: Provides robust screen-reader labels for core action buttons, adhering to WCAG guidelines for icon-only interactive elements.

_Note: Kept changes well under the 50-line limit by focusing on the most used action buttons in the main queue list views._

---
*PR created automatically by Jules for task [5690929416568720792](https://jules.google.com/task/5690929416568720792) started by @kshramt*