### PR TITLE
⚡ Bolt: [performance improvement] Add React.memo to QueueEntry and MobileQueueNode

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,18 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,7 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1235,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What:** Wrapped `QueueEntry` and `MobileQueueNode` components with `React.memo()`.

🎯 **Why:** Both components accept simple primitive properties (`node_id`, `index`) and are rendered in large mapped lists or virtualized lists (`react-virtuoso`). Without `React.memo`, these components will un-necessarily re-render whenever the parent component updates, leading to O(N) re-renders across all items in the list.

📊 **Impact:** Reduces unnecessary component re-renders during state updates and scrolling for both `TodoQueueEntry` and `MobileQueueNode`. This is a targeted O(N) performance improvement. 

🔬 **Measurement:** Use React Developer Tools Profiler. Start recording, scroll down the virtualized queue, or trigger a global state update. With the optimization, the time spent re-rendering list items that haven't explicitly changed should be minimal, shown by gray un-rendered items in the React Profiler flamegraph.

---
*PR created automatically by Jules for task [15337768682799429968](https://jules.google.com/task/15337768682799429968) started by @kshramt*