### PR TITLE
🛡️ Sentinel: [security improvement] Add strict security headers to API endpoints

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -389,6 +390,28 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: The API lacked strict default security headers, leaving potential blind spots against specific types of browser-based attacks or misconfigurations (e.g., MIME sniffing, clickjacking if embedded, lack of strict HTTPS enforcement).
🎯 Impact: Implementing strict security headers provides defense-in-depth, reducing the risk of XSS, framing attacks, and enforcing secure connections.
🔧 Fix: Configured `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs` to enforce CSP (`default-src 'none'`), HSTS, X-Frame-Options (`DENY`), X-Content-Type-Options (`nosniff`), and Referrer-Policy (`no-referrer`).
✅ Verification: Ran `cargo test`, `cargo clippy`, and client test suite (`check.sh`) to ensure no regressions. The headers are applied unconditionally to all API responses.

---
*PR created automatically by Jules for task [16701880859147012288](https://jules.google.com/task/16701880859147012288) started by @kshramt*