### PR TITLE
🎨 Palette: [a11y improvement] Add aria-hidden to material-icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+**/dist/

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Material Icons Need aria-hidden="true"
+**Learning:** Material UI icon spans (e.g., `<span className="material-icons">`) must include `aria-hidden="true"` to prevent screen readers from incorrectly announcing their ligature text, ensuring parent elements (like buttons) dictate the accessible name.
+**Action:** Always add `aria-hidden="true"` to material-icons spans across the codebase.

--- a/client/src/Header/MenuButton/index.tsx
+++ b/client/src/Header/MenuButton/index.tsx
@@ -50,7 +50,9 @@ const MenuButton = (props: {
           onClick={handleButtonClick}
           className="btn-icon"
         >
-          <span className="material-icons">menu</span>
+          <span className="material-icons" aria-hidden="true">
+            menu
+          </span>
         </button>
       </Menu.Target>
 

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -48,11 +48,15 @@ import * as ops from "./ops";
 import * as undoable from "./undoable";
 
 const SCROLL_BACK_TO_TOP_MARK = (
-  <span className="material-icons">vertical_align_top</span>
+  <span className="material-icons" aria-hidden="true">
+    vertical_align_top
+  </span>
 );
 
 const SCROLL_BACK_TO_BOTTOM_MARK = (
-  <span className="material-icons">vertical_align_bottom</span>
+  <span className="material-icons" aria-hidden="true">
+    vertical_align_bottom
+  </span>
 );
 
 const nonTodoQueueNodesRef = React.createRef<Rv.VirtuosoHandle>();
@@ -442,7 +446,9 @@ const Menu = (props: {
         onClick={_redo}
         onDoubleClick={prevent_propagation}
       >
-        <span className="material-icons">redo</span>
+        <span className="material-icons" aria-hidden="true">
+          redo
+        </span>
       </button>
       <Mt.Switch
         checked={sortByCtime}
@@ -1150,7 +1156,9 @@ const MobileMenu = (props: {
         onClick={_redo}
         onDoubleClick={prevent_propagation}
       >
-        <span className="material-icons">redo</span>
+        <span className="material-icons" aria-hidden="true">
+          redo
+        </span>
       </button>
       <Mt.Switch
         checked={show_todo_only}

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -4,40 +4,128 @@ export const MINUTE = 60 * 1_000;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
 
-export const DELETE_MARK = <span className="material-icons">close</span>;
+export const DELETE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    close
+  </span>
+);
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
+export const START_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    play_arrow
+  </span>
+);
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons">double_arrow</span>
+  <span className="material-icons" aria-hidden="true">
+    double_arrow
+  </span>
 );
-export const ADD_MARK = <span className="material-icons">add</span>;
-export const DONE_MARK = <span className="material-icons">done</span>;
-export const DONT_MARK = <span className="material-icons">delete</span>;
-export const DETAIL_MARK = <span className="material-icons">more_vert</span>;
-export const COPY_MARK = <span className="material-icons">content_copy</span>;
-export const STOP_MARK = <span className="material-icons">stop</span>;
-export const TOP_MARK = <span className="material-icons">arrow_upward</span>;
-export const UNDO_MARK = <span className="material-icons">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons">south</span>;
-export const EVAL_MARK = <span className="material-icons">functions</span>;
-export const TOC_MARK = <span className="material-icons">toc</span>;
+export const ADD_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    add
+  </span>
+);
+export const DONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    done
+  </span>
+);
+export const DONT_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    delete
+  </span>
+);
+export const DETAIL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    more_vert
+  </span>
+);
+export const COPY_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_copy
+  </span>
+);
+export const STOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    stop
+  </span>
+);
+export const TOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_upward
+  </span>
+);
+export const UNDO_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    undo
+  </span>
+);
+export const MOVE_UP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    north
+  </span>
+);
+export const MOVE_DOWN_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    south
+  </span>
+);
+export const EVAL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    functions
+  </span>
+);
+export const TOC_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    toc
+  </span>
+);
 export const FORWARD_MARK = (
-  <span className="material-icons">arrow_forward_ios</span>
+  <span className="material-icons" aria-hidden="true">
+    arrow_forward_ios
+  </span>
 );
-export const BACK_MARK = <span className="material-icons">arrow_back_ios</span>;
-export const SEARCH_MARK = <span className="material-icons">search</span>;
-export const IDS_MARK = <span className="material-icons">content_paste</span>;
-export const MOBILE_MARK = <span className="material-icons">smartphone</span>;
+export const BACK_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_back_ios
+  </span>
+);
+export const SEARCH_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    search
+  </span>
+);
+export const IDS_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_paste
+  </span>
+);
+export const MOBILE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    smartphone
+  </span>
+);
 export const DESKTOP_MARK = (
-  <span className="material-icons">desktop_windows</span>
+  <span className="material-icons" aria-hidden="true">
+    desktop_windows
+  </span>
 );
-export const IS_FULL_MARK = <span className="material-icons">expand_more</span>;
-export const IS_NONE_MARK = <span className="material-icons">expand_less</span>;
+export const IS_FULL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_more
+  </span>
+);
+export const IS_NONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_less
+  </span>
+);
 export const IS_PARTIAL_MARK = (
-  <span className="material-icons">chevron_right</span>
+  <span className="material-icons" aria-hidden="true">
+    chevron_right
+  </span>
 );
 
 export const SPINNER = (


### PR DESCRIPTION
💡 **What:** Added `aria-hidden="true"` to `<span className="material-icons">` elements.
🎯 **Why:** To improve accessibility for screen readers. Without this, screen readers may read the text content of the material icon span (e.g., "add", "play_arrow"), which can be confusing when the icon is part of a button that already has an `aria-label` or `title`.
♿ **Accessibility:** This directly addresses a critical accessibility concern for visually impaired users relying on screen readers. It ensures the parent's accessible name is the only one read, not the icon ligature.

---
*PR created automatically by Jules for task [9391002670755550407](https://jules.google.com/task/9391002670755550407) started by @kshramt*