### PR TITLE
⚡ Bolt: Wrap queue nodes in React.memo to prevent O(N) re-renders

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,11 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+/**
+ * ⚡ Bolt: Wraps QueueEntry with React.memo to prevent O(N) re-renders
+ * when scrolling or updating unrelated items in the virtualized list.
+ */
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +33,7 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -21,19 +21,18 @@ import TopButton from "./TopButton";
  * ⚡ Bolt: Wraps QueueEntry with React.memo to prevent O(N) re-renders
  * when scrolling or updating unrelated items in the virtualized list.
  */
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,11 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/**
+ * ⚡ Bolt: Wraps MobileQueueNode with React.memo to prevent O(N) re-renders
+ * when scrolling or updating unrelated items in the virtualized list.
+ */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1239,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What**: Wrapped `QueueEntry` (in `client/src/QueueEntry.tsx`) and `MobileQueueNode` (in `client/src/components.tsx`) with `React.memo()`.

🎯 **Why**: These components represent items in virtualized lists (like `react-virtuoso` queues) and mapped arrays. Since they only receive simple, stable primitive props (`node_id`, `index`), they don't need to re-render unless these specific props change. Without memoization, global state changes or scrolling events could trigger expensive O(N) re-renders across all visible list items.

📊 **Impact**: Eliminates unnecessary React reconciliation for queue list items. Scrolling performance and unrelated state updates will be significantly smoother with fewer rendering bottlenecks on the main thread.

🔬 **Measurement**: 
1. Open the application with a large list of nodes in the "To Do" or queue columns.
2. Use the React DevTools Profiler.
3. Perform an action that updates a separate part of the application state (like changing a filter or typing in an input).
4. Verify in the Profiler that the `QueueEntry` and `MobileQueueNode` components are greyed out (memoized) instead of highlighted for re-rendering.

---
*PR created automatically by Jules for task [17244963610456349165](https://jules.google.com/task/17244963610456349165) started by @kshramt*