### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix missing security headers in api_v2

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Missing Security Headers in Axum v0.7
+**Vulnerability:** The Axum v0.7 application (`api_v2`) lacked basic security headers by default, exposing users to risks like XSS, clickjacking, and MIME sniffing attacks.
+**Learning:** Axum, unlike some older or different ecosystem frameworks, does not set default security headers out-of-the-box. They must be explicitly configured using middleware.
+**Prevention:** Use `tower_http::set_header::SetResponseHeaderLayer` to globally enforce headers such as `Content-Security-Policy` (e.g., `default-src 'none'; frame-ancestors 'none'; sandbox`), `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` when setting up the application `Router`.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,7 +391,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Axum v0.7 application (`api_v2`) lacked basic security headers by default, exposing users to risks like XSS, clickjacking, and MIME sniffing attacks.
🎯 Impact: Attackers could potentially frame the application, execute unauthorized scripts if injected, or exploit MIME type confusion.
🔧 Fix: Configured `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs` to enforce strong security headers including `Content-Security-Policy` (`default-src 'none'; frame-ancestors 'none'; sandbox`), `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`. Also suppressed a dead-code warning in the auto-generated code for CI passing.
✅ Verification: Ran `cargo check`, `cargo test`, and `cargo clippy` which passed. Checked for cleanliness by verifying no scratchpad scripts are committed.

---
*PR created automatically by Jules for task [1452021503353835513](https://jules.google.com/task/1452021503353835513) started by @kshramt*