### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +422,86 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let state = std::sync::Arc::new(AppState::new(
+            0,
+            sqlx::postgres::PgPoolOptions::new()
+                .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+                .unwrap(),
+        ));
+        let app = axum::Router::new();
+        let app = gen::register_app::<ApiImpl>(app);
+        let app = app.with_state(state);
+        let app = app
+            .layer(tower_http::trace::TraceLayer::new_for_http())
+            .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+            .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::CONTENT_SECURITY_POLICY,
+                axum::http::HeaderValue::from_static(
+                    "default-src 'none'; frame-ancestors 'none'; sandbox",
+                ),
+            ))
+            .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::STRICT_TRANSPORT_SECURITY,
+                axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+            ))
+            .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::X_FRAME_OPTIONS,
+                axum::http::HeaderValue::from_static("DENY"),
+            ))
+            .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::X_CONTENT_TYPE_OPTIONS,
+                axum::http::HeaderValue::from_static("nosniff"),
+            ))
+            .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+                axum::http::header::REFERRER_POLICY,
+                axum::http::HeaderValue::from_static("no-referrer"),
+            ));
+
+        let req = Request::builder()
+            .uri("/api/v2/not-found")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = app.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), axum::http::StatusCode::NOT_FOUND);
+
+        let headers = res.headers();
+        assert_eq!(
+            headers
+                .get(axum::http::header::CONTENT_SECURITY_POLICY)
+                .unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers
+                .get(axum::http::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(
+            headers.get(axum::http::header::X_FRAME_OPTIONS).unwrap(),
+            "DENY"
+        );
+        assert_eq!(
+            headers
+                .get(axum::http::header::X_CONTENT_TYPE_OPTIONS)
+                .unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            headers.get(axum::http::header::REFERRER_POLICY).unwrap(),
+            "no-referrer"
+        );
+    }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The API lacked essential security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy), making the application potentially vulnerable to attacks like XSS, clickjacking, and MIME-sniffing.
🎯 Impact: Without these headers, an attacker could embed the API in an iframe, trick the browser into executing malicious scripts, or perform MIME-sniffing attacks.
🔧 Fix: Used `tower_http::set_header::SetResponseHeaderLayer` to add standard security headers to the main Axum application router. Added an integration test verifying the headers are set.
✅ Verification: Ran `cargo test` in `api_v2/` to ensure the new middleware applies the headers correctly on requests like `/api/v2/not-found`.

---
*PR created automatically by Jules for task [15685305887666974521](https://jules.google.com/task/15685305887666974521) started by @kshramt*