### PR TITLE
⚡ Bolt: Prevent unnecessary O(N) re-renders in Queue views

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Explicit React.memo required for Virtuoso list items
+**Learning:** In `react-virtuoso` virtualized lists or mapped arrays, list item components receiving primitive props (e.g., `node_id`, `index`) must be explicitly wrapped in `React.memo` (like `QueueEntry` or `MobileQueueNode`). Otherwise, scrolling or state updates trigger O(N) re-renders for every rendered item in the virtualized window, causing significant main-thread lag.
+**Action:** Always wrap list/array items receiving primitives in `React.memo` when rendering multiple items within this application's architecture.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,19 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Wrapped in React.memo to prevent O(N) re-renders in Virtuoso virtualized lists during scrolling and state updates */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Wrapped in React.memo to prevent unnecessary re-renders in mapped arrays */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` and `MobileQueueNode` components in `React.memo()`.

🎯 Why: In `react-virtuoso` virtualized lists or mapped arrays, list item components receiving primitive props (e.g., `node_id`, `index`) must be explicitly wrapped in `React.memo`. Otherwise, scrolling or global state updates trigger O(N) re-renders for every rendered item in the virtualized window, causing significant main-thread lag. `QueueEntry` and `MobileQueueNode` both only receive the primitive `node_id` and/or `index`, making them perfect candidates for `React.memo`.

📊 Impact: Reduces unnecessary re-renders in the queue views during scrolling and non-local state updates, decreasing main thread blocking time.

🔬 Measurement: Verifiable by using the React DevTools Profiler, recording a scrolling interaction in the "To Do" queue, and confirming that individual `QueueEntry` or `MobileQueueNode` components no longer re-render unless their specific slice of state changes. Tests and linting also pass, confirming no regressions.

* Added `React.memo` comment: `/** ⚡ Bolt: ... */`
* Logged codebase-specific learning in `.jules/bolt.md`

---
*PR created automatically by Jules for task [13003668393095826346](https://jules.google.com/task/13003668393095826346) started by @kshramt*