### PR TITLE
🛡️ Sentinel: [security improvement] Add Baseline HTTP Security Headers to API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-24 - [Missing Security Headers in API]
+**Vulnerability:** The Axum `api_v2` backend lacked baseline HTTP security headers (e.g. CSP, X-Frame-Options, HSTS, X-Content-Type-Options, Referrer-Policy).
+**Learning:** Axum v0.7 does not set these by default. Nginx proxy settings were only applying some headers like CSP frame-ancestors to HTML content, leaving pure API endpoints exposed.
+**Prevention:** Ensure new Axum services or endpoints enforce strict HTTP security headers via `tower_http::set_header::SetResponseHeaderLayer` by default.

--- a/api_v2/run_test.sh
+++ b/api_v2/run_test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cargo test

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,3 +1,5 @@
+use axum::http::header;
+use axum::http::HeaderValue;
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
     http::request::Parts,
@@ -13,11 +15,13 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -389,6 +393,26 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(SetResponseHeaderLayer::if_not_present(
+            header::CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            header::STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            header::REFERRER_POLICY,
+            HeaderValue::from_static("no-referrer"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Axum `api_v2` backend lacked baseline HTTP security headers. While Nginx in production adds some headers for `text/html`, pure API endpoints exposed directly by Axum lacked robust defense-in-depth security layers.
🎯 Impact: Without headers like CSP, X-Frame-Options, HSTS, and nosniff, API endpoints might be susceptible to attacks such as cross-site scripting (if they inadvertently return HTML/content without strict types), clickjacking, and mime-sniffing.
🔧 Fix: Configured `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs` to enforce strong HTTP security headers globally for all API responses. Added `#allow(dead_code)` for the generated code module so `cargo clippy -- -D warnings` passes.
✅ Verification: Ensure tests pass locally (ran `cargo test` in `api_v2/` and `client/scripts/check.sh`). Verified `cargo fmt` and `cargo clippy` pass successfully.

---
*PR created automatically by Jules for task [18063706178841043220](https://jules.google.com/task/18063706178841043220) started by @kshramt*