### PR TITLE
🛡️ Sentinel: [security improvement] Add strict security headers to API

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -389,6 +390,28 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `api_v2` Axum service did not explicitly set security-related HTTP response headers. Axum does not set these by default, which can lead to various client-side risks such as MIME-type sniffing, clickjacking, and XSS execution risks.
🎯 Impact: Without these headers, a malicious actor might try to load the API in an iframe or trick the browser into interpreting an API response as HTML/script, leading to unintended consequences or data leakage.
🔧 Fix: Added five security header layers using `tower_http::set_header::SetResponseHeaderLayer` to the `axum` router in `api_v2/src/main.rs`. Included strict but appropriate values for a backend data API (e.g. `default-src 'none'`). Also suppressed an unused code warning from the generated endpoints to fix compilation warnings in CI.
✅ Verification: Ensure the service compiles and tests run cleanly. Can be manually verified by inspecting HTTP response headers from `/api/v2/*` routes.

---
*PR created automatically by Jules for task [667195251244955853](https://jules.google.com/task/667195251244955853) started by @kshramt*