### PR TITLE
⚡ Bolt: [performance improvement] Add React.memo to QueueEntry and MobileQueueNode

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,19 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Wrapped in React.memo to prevent unnecessary O(N) re-renders during virtualized list scrolling and state updates. */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Wrapped in React.memo to prevent unnecessary O(N) re-renders during state updates in mapped arrays. */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What:**
Wrapped `QueueEntry` and `MobileQueueNode` components in `React.memo()`.

🎯 **Why:**
These components receive primitive props (like `node_id` or `nodeId` and `index`) and are rendered in lists (like `react-virtuoso` virtualized lists or mapped arrays). Without `React.memo`, any state update in the parent that causes it to re-render will force all child list items to re-render, resulting in an O(N) performance hit. 

📊 **Impact:**
Significantly reduces unnecessary re-renders during scrolling and unrelated state updates, leading to a smoother user experience, particularly on larger task queues.

🔬 **Measurement:**
This improvement can be verified using React DevTools' Profiler to observe component rendering while scrolling or updating unrelated application state. `QueueEntry` and `MobileQueueNode` should no longer show as re-rendering unless their specific props or internal states change.

---
*PR created automatically by Jules for task [13034663185724410195](https://jules.google.com/task/13034663185724410195) started by @kshramt*