### PR TITLE
⚡ Bolt: [performance improvement] Memoize list item components

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,8 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+/** ⚡ Bolt: Memoize list item components receiving primitive props (node_id, index) to prevent unnecessary O(N) re-renders during scrolling and state updates within react-virtuoso virtualized lists. */
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +30,7 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -18,19 +18,18 @@ import * as utils from "./utils";
 import TopButton from "./TopButton";
 
 /** ⚡ Bolt: Memoize list item components receiving primitive props (node_id, index) to prevent unnecessary O(N) re-renders during scrolling and state updates within react-virtuoso virtualized lists. */
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Memoize list item components receiving primitive props (node_id) to prevent unnecessary O(N) re-renders during state updates within mapped arrays. */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What:** 
Wrapped the `QueueEntry` (`client/src/QueueEntry.tsx`) and `MobileQueueNode` (`client/src/components.tsx`) list item components in `React.memo`.

🎯 **Why:** 
These components are heavily used inside `react-virtuoso` virtualized lists and mapped arrays. They accept primitive props (`node_id`, `index`). Without memoization, they re-render globally during any parent state update (e.g., scrolling, global queue updates), causing an O(N) performance drag.

📊 **Impact:** 
Significantly reduces React render tree depth and execution time during scrolling and state updates within the todo/non-todo queues. List items will now only re-render when their specific `node_id` or `index` changes.

🔬 **Measurement:** 
Run React Profiler while scrolling the queue or updating an entry's status. Observe that siblings to the updated entry do not unnecessarily commit new render cycles. Verified via `./scripts/check.sh` test suite.

---
*PR created automatically by Jules for task [849717781552906982](https://jules.google.com/task/849717781552906982) started by @kshramt*