### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to icon-only buttons

### DIFF
--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move Up"
+      title="Move Up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +79,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move Down"
+      title="Move Down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      aria-label="Stop"
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as Done"
+      title="Mark as Done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as Won't Do"
+      title="Mark as Won't Do"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -4,40 +4,128 @@ export const MINUTE = 60 * 1_000;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
 
-export const DELETE_MARK = <span className="material-icons" aria-hidden="true">close</span>;
+export const DELETE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    close
+  </span>
+);
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons" aria-hidden="true">play_arrow</span>;
+export const START_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    play_arrow
+  </span>
+);
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons" aria-hidden="true">double_arrow</span>
+  <span className="material-icons" aria-hidden="true">
+    double_arrow
+  </span>
 );
-export const ADD_MARK = <span className="material-icons" aria-hidden="true">add</span>;
-export const DONE_MARK = <span className="material-icons" aria-hidden="true">done</span>;
-export const DONT_MARK = <span className="material-icons" aria-hidden="true">delete</span>;
-export const DETAIL_MARK = <span className="material-icons" aria-hidden="true">more_vert</span>;
-export const COPY_MARK = <span className="material-icons" aria-hidden="true">content_copy</span>;
-export const STOP_MARK = <span className="material-icons" aria-hidden="true">stop</span>;
-export const TOP_MARK = <span className="material-icons" aria-hidden="true">arrow_upward</span>;
-export const UNDO_MARK = <span className="material-icons" aria-hidden="true">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons" aria-hidden="true">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons" aria-hidden="true">south</span>;
-export const EVAL_MARK = <span className="material-icons" aria-hidden="true">functions</span>;
-export const TOC_MARK = <span className="material-icons" aria-hidden="true">toc</span>;
+export const ADD_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    add
+  </span>
+);
+export const DONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    done
+  </span>
+);
+export const DONT_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    delete
+  </span>
+);
+export const DETAIL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    more_vert
+  </span>
+);
+export const COPY_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_copy
+  </span>
+);
+export const STOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    stop
+  </span>
+);
+export const TOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_upward
+  </span>
+);
+export const UNDO_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    undo
+  </span>
+);
+export const MOVE_UP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    north
+  </span>
+);
+export const MOVE_DOWN_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    south
+  </span>
+);
+export const EVAL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    functions
+  </span>
+);
+export const TOC_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    toc
+  </span>
+);
 export const FORWARD_MARK = (
-  <span className="material-icons" aria-hidden="true">arrow_forward_ios</span>
+  <span className="material-icons" aria-hidden="true">
+    arrow_forward_ios
+  </span>
 );
-export const BACK_MARK = <span className="material-icons" aria-hidden="true">arrow_back_ios</span>;
-export const SEARCH_MARK = <span className="material-icons" aria-hidden="true">search</span>;
-export const IDS_MARK = <span className="material-icons" aria-hidden="true">content_paste</span>;
-export const MOBILE_MARK = <span className="material-icons" aria-hidden="true">smartphone</span>;
+export const BACK_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_back_ios
+  </span>
+);
+export const SEARCH_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    search
+  </span>
+);
+export const IDS_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_paste
+  </span>
+);
+export const MOBILE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    smartphone
+  </span>
+);
 export const DESKTOP_MARK = (
-  <span className="material-icons" aria-hidden="true">desktop_windows</span>
+  <span className="material-icons" aria-hidden="true">
+    desktop_windows
+  </span>
 );
-export const IS_FULL_MARK = <span className="material-icons" aria-hidden="true">expand_more</span>;
-export const IS_NONE_MARK = <span className="material-icons" aria-hidden="true">expand_less</span>;
+export const IS_FULL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_more
+  </span>
+);
+export const IS_NONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_less
+  </span>
+);
 export const IS_PARTIAL_MARK = (
-  <span className="material-icons" aria-hidden="true">chevron_right</span>
+  <span className="material-icons" aria-hidden="true">
+    chevron_right
+  </span>
 );
 
 export const SPINNER = (

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -4,40 +4,40 @@ export const MINUTE = 60 * 1_000;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
 
-export const DELETE_MARK = <span className="material-icons">close</span>;
+export const DELETE_MARK = <span className="material-icons" aria-hidden="true">close</span>;
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
+export const START_MARK = <span className="material-icons" aria-hidden="true">play_arrow</span>;
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons">double_arrow</span>
+  <span className="material-icons" aria-hidden="true">double_arrow</span>
 );
-export const ADD_MARK = <span className="material-icons">add</span>;
-export const DONE_MARK = <span className="material-icons">done</span>;
-export const DONT_MARK = <span className="material-icons">delete</span>;
-export const DETAIL_MARK = <span className="material-icons">more_vert</span>;
-export const COPY_MARK = <span className="material-icons">content_copy</span>;
-export const STOP_MARK = <span className="material-icons">stop</span>;
-export const TOP_MARK = <span className="material-icons">arrow_upward</span>;
-export const UNDO_MARK = <span className="material-icons">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons">south</span>;
-export const EVAL_MARK = <span className="material-icons">functions</span>;
-export const TOC_MARK = <span className="material-icons">toc</span>;
+export const ADD_MARK = <span className="material-icons" aria-hidden="true">add</span>;
+export const DONE_MARK = <span className="material-icons" aria-hidden="true">done</span>;
+export const DONT_MARK = <span className="material-icons" aria-hidden="true">delete</span>;
+export const DETAIL_MARK = <span className="material-icons" aria-hidden="true">more_vert</span>;
+export const COPY_MARK = <span className="material-icons" aria-hidden="true">content_copy</span>;
+export const STOP_MARK = <span className="material-icons" aria-hidden="true">stop</span>;
+export const TOP_MARK = <span className="material-icons" aria-hidden="true">arrow_upward</span>;
+export const UNDO_MARK = <span className="material-icons" aria-hidden="true">undo</span>;
+export const MOVE_UP_MARK = <span className="material-icons" aria-hidden="true">north</span>;
+export const MOVE_DOWN_MARK = <span className="material-icons" aria-hidden="true">south</span>;
+export const EVAL_MARK = <span className="material-icons" aria-hidden="true">functions</span>;
+export const TOC_MARK = <span className="material-icons" aria-hidden="true">toc</span>;
 export const FORWARD_MARK = (
-  <span className="material-icons">arrow_forward_ios</span>
+  <span className="material-icons" aria-hidden="true">arrow_forward_ios</span>
 );
-export const BACK_MARK = <span className="material-icons">arrow_back_ios</span>;
-export const SEARCH_MARK = <span className="material-icons">search</span>;
-export const IDS_MARK = <span className="material-icons">content_paste</span>;
-export const MOBILE_MARK = <span className="material-icons">smartphone</span>;
+export const BACK_MARK = <span className="material-icons" aria-hidden="true">arrow_back_ios</span>;
+export const SEARCH_MARK = <span className="material-icons" aria-hidden="true">search</span>;
+export const IDS_MARK = <span className="material-icons" aria-hidden="true">content_paste</span>;
+export const MOBILE_MARK = <span className="material-icons" aria-hidden="true">smartphone</span>;
 export const DESKTOP_MARK = (
-  <span className="material-icons">desktop_windows</span>
+  <span className="material-icons" aria-hidden="true">desktop_windows</span>
 );
-export const IS_FULL_MARK = <span className="material-icons">expand_more</span>;
-export const IS_NONE_MARK = <span className="material-icons">expand_less</span>;
+export const IS_FULL_MARK = <span className="material-icons" aria-hidden="true">expand_more</span>;
+export const IS_NONE_MARK = <span className="material-icons" aria-hidden="true">expand_less</span>;
 export const IS_PARTIAL_MARK = (
-  <span className="material-icons">chevron_right</span>
+  <span className="material-icons" aria-hidden="true">chevron_right</span>
 );
 
 export const SPINNER = (


### PR DESCRIPTION
### 💡 What: \nAdded `aria-label` and `title` attributes to commonly used icon-only action buttons across the app (`StartButton`, `StopButton`, `TodoToDoneButton`, `TodoToDontButton`, and `EntryButtons` movement buttons). Also added `aria-hidden="true"` to the `material-icons` spans used to render icons.\n\n### 🎯 Why: \nIcon-only buttons must have an accessible name for screen reader users and a visual tooltip (`title`) for sighted users who need clarification on what an icon does. Without `aria-hidden="true"` on the icon itself, screen readers often read the ligature text (e.g., "play arrow") instead of the semantic button action.\n\n### 📸 Before/After: \n*Before:* Hovering over a task action button provided no tooltip. Screen readers received no explicit button label.\n*After:* Hovering over task actions reveals clear tooltips like "Start", "Mark as Done", etc.\n\n### ♿ Accessibility: \n- Added `aria-label` to buttons without them.\n- Ensured `material-icons` spans do not clutter the accessibility tree using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [15956260356028958462](https://jules.google.com/task/15956260356028958462) started by @kshramt*