### PR TITLE
🎨 Palette: Add aria-label to Menu button

### DIFF
--- a/client/src/Header/MenuButton/index.tsx
+++ b/client/src/Header/MenuButton/index.tsx
@@ -49,8 +49,11 @@ const MenuButton = (props: {
           ref={menuButtonRef}
           onClick={handleButtonClick}
           className="btn-icon"
+          aria-label="Open menu"
         >
-          <span className="material-icons">menu</span>
+          <span className="material-icons" aria-hidden="true">
+            menu
+          </span>
         </button>
       </Menu.Target>
 


### PR DESCRIPTION
💡 What: Added `aria-label="Open menu"` to the `<button>` and `aria-hidden="true"` to the `material-icons` `<span>` in `client/src/Header/MenuButton/index.tsx`.

🎯 Why: The `MenuButton` is an icon-only button without visible text. Previously, screen readers would incorrectly announce the ligature text "menu" inside the `span`. Adding an `aria-label` provides a proper accessible name, and hiding the `span` prevents the ligature text from adding semantic noise.

♿ Accessibility: Ensures the icon-only menu button is correctly announced by screen readers as "Open menu", improving keyboard navigation and overall usability for visually impaired users.

---
*PR created automatically by Jules for task [14792514002486860347](https://jules.google.com/task/14792514002486860347) started by @kshramt*