### PR TITLE
⚡ Bolt: Memoize list item components to prevent O(N) re-renders

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,19 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Memoize list item component to prevent O(N) re-renders during scrolling and state updates within react-virtuoso virtualized lists. */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Memoize list item component to prevent O(N) re-renders during scrolling and state updates within mapped arrays. */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` and `MobileQueueNode` components in `React.memo()` in `client/src/QueueEntry.tsx` and `client/src/components.tsx`.
🎯 Why: These list items receive primitive props (`node_id`, `index`) and are rendered within mapped arrays or `react-virtuoso` virtualized lists. Without memoization, they re-render unnecessarily on every parent update, leading to O(N) re-renders during scrolling or state updates.
📊 Impact: Significantly reduces O(N) list re-renders during interactions like scrolling and data updates.
🔬 Measurement: Verified with `./scripts/check.sh` ensuring all tests and typings remain correct. Performance improvements can be confirmed via React DevTools Profiler during scrolling.

---
*PR created automatically by Jules for task [11628430170762612655](https://jules.google.com/task/11628430170762612655) started by @kshramt*