### PR TITLE
🛡️ Sentinel: [MEDIUM] Add strict security headers to API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-05-24 - Missing Strict Security Headers in Axum Router
+
+**Vulnerability:** The Axum router for the `api_v2` backend service did not set critical security headers (like Content-Security-Policy, Strict-Transport-Security, X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+**Learning:** Axum 0.7 does not set security headers by default. A strict CSP (`default-src 'none'`) and other headers must be explicitly configured using `tower_http::set_header::SetResponseHeaderLayer` in the main router setup to establish a secure baseline for the API responses.
+**Prevention:** Include a standard security headers configuration (e.g., using `tower-http`) when defining the global Axum app router, extracting it into a reusable `app` function for testability.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,38 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: std::sync::Arc<AppState>) -> axum::Router {
+    use tower_http::set_header::SetResponseHeaderLayer;
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        // 🛡️ Sentinel: Enforce strict security headers
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +417,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Axum router for the `api_v2` backend service did not set critical security headers (like Content-Security-Policy, Strict-Transport-Security, X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
🎯 Impact: Missing security headers leaves the API susceptible to various common web vulnerabilities like MIME-sniffing, framing/clickjacking, and cross-site injections if responses are loaded into a browser context.
🔧 Fix: Extracted the router initialization to a reusable `app` function and added `tower_http::set_header::SetResponseHeaderLayer` to explicitly configure strict CSP (`default-src 'none'`) and other essential security headers.
✅ Verification: `cargo test` and `cargo clippy` pass in `api_v2`, `make check` passes in root, and code diff confirms headers are injected correctly on all API routes. Also added a journal entry in `.jules/sentinel.md` documenting the learning.

---
*PR created automatically by Jules for task [6658060312488651747](https://jules.google.com/task/6658060312488651747) started by @kshramt*