### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label and title to StartButton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 # production
 **/build/
+**/dist/
+**/dev-dist/
 
 # misc
 .DS_Store

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 **What**: Added `aria-label="Start"` and `title="Start"` to the `StartButton` component. Added `**/dist/` and `**/dev-dist/` to `.gitignore`.
🎯 **Why**: The `StartButton` is an icon-only button without any accessible name or tooltip text. This makes it difficult for screen readers to interpret and leaves mouse users without native tooltip functionality. The `.gitignore` update prevents production build artifacts (`client/dist`) from being accidentally committed, preventing version control bloat and merge conflicts.
♿ **Accessibility**: Provides an accessible name for screen readers, allowing them to announce "Start button" instead of ignoring it or guessing based on the DOM content. Adds a native tooltip for mouse users on hover.

---
*PR created automatically by Jules for task [7410937301568731199](https://jules.google.com/task/7410937301568731199) started by @kshramt*