### PR TITLE
⚡ Bolt: [performance improvement] Optimize QueueEntry and MobileQueueNode renders

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,19 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: wrap QueueEntry with React.memo to prevent O(N) re-renders during virtualized list scrolling/updates */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: wrap MobileQueueNode with React.memo to prevent O(N) re-renders for mapped arrays */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What**: Wrapped `QueueEntry` and `MobileQueueNode` in `React.memo` and added brief comments explaining the optimization.
🎯 **Why**: Both components are list items receiving simple, primitive props (`node_id` and `index`). Without memoization, any state update in their parent containers (like `react-virtuoso` lists or mapped arrays) triggers a re-render of every single item, resulting in an O(N) performance cost during scrolling or global updates.
📊 **Impact**: Reduces unnecessary re-renders in the main desktop and mobile queue lists by ~100% when parent state changes without affecting the specific item's props, significantly improving scrolling performance and responsiveness on larger lists.
🔬 **Measurement**: Use the React Developer Tools Profiler to record scrolling through the TodoQueue or nonTodoQueue. The "Highlight updates when components render" feature will now show that unmodified rows no longer flash during scroll updates.

---
*PR created automatically by Jules for task [371533538246281040](https://jules.google.com/task/371533538246281040) started by @kshramt*