### PR TITLE
🎨 Palette: [Accessibility] Add ARIA attributes to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+# Palette Journal
+
+
+## 2024-05-18 - Added ARIA attributes to icon-only buttons
+**Learning:** Material UI icon spans (e.g., `<span className="material-icons">`) must include `aria-hidden="true"` to prevent screen readers from incorrectly announcing their ligature text. Crucially, when applying this to icon-only buttons, the parent element (e.g., `<button>`) MUST be given a descriptive `aria-label` to ensure it still has an accessible name, avoiding severe accessibility regressions.
+**Action:** Always add `aria-label` (and optionally `title` for hover tooltips) to icon-only buttons, and ensure child ligature icons are hidden from screen readers with `aria-hidden="true"`.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -27,7 +27,9 @@ export const AddButton = (props: {
   }, [props.node_id, dispatch, show_mobile, prefix]);
   return (
     <button
-      className="btn-icon" aria-label="Add" title="Add"
+      className="btn-icon"
+      aria-label="Add"
+      title="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -27,7 +27,7 @@ export const AddButton = (props: {
   }, [props.node_id, dispatch, show_mobile, prefix]);
   return (
     <button
-      className="btn-icon"
+      className="btn-icon" aria-label="Add" title="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -22,7 +22,7 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   );
   return (
     <button
-      className="btn-icon"
+      className="btn-icon" aria-label="Copy ID" title="Copy ID"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -22,7 +22,9 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   );
   return (
     <button
-      className="btn-icon" aria-label="Copy ID" title="Copy ID"
+      className="btn-icon"
+      aria-label="Copy ID"
+      title="Copy ID"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -13,7 +13,7 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
-      className="btn-icon"
+      className="btn-icon" aria-label="Undo" title="Undo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -13,7 +13,9 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
-      className="btn-icon" aria-label="Undo" title="Undo"
+      className="btn-icon"
+      aria-label="Undo"
+      title="Undo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -57,6 +57,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move up"
+      title="Move up"
       className="btn-icon"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
@@ -76,6 +78,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move down"
+      title="Move down"
       className="btn-icon"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -14,7 +14,7 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
-      className="btn-icon"
+      className="btn-icon" aria-label="Evaluate" title="Evaluate"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -14,7 +14,9 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
-      className="btn-icon" aria-label="Evaluate" title="Evaluate"
+      className="btn-icon"
+      aria-label="Evaluate"
+      title="Evaluate"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -74,14 +74,18 @@ const Details = (props: { node_id: types.TNodeId }) => {
           ))}
         </select>
         <button
-          className="btn-icon" aria-label="Show details" title="Show details"
+          className="btn-icon"
+          aria-label="Show details"
+          title="Show details"
           onClick={handle_add_parents}
           onDoubleClick={utils.prevent_propagation}
         >
           Parents
         </button>
         <button
-          className="btn-icon" aria-label="Show details" title="Show details"
+          className="btn-icon"
+          aria-label="Show details"
+          title="Show details"
           onClick={handle_add_children}
           onDoubleClick={utils.prevent_propagation}
         >
@@ -108,7 +112,9 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   }, [dispatch, props.node_id]);
   return (
     <button
-      className="btn-icon" aria-label="Show details" title="Show details"
+      className="btn-icon"
+      aria-label="Show details"
+      title="Show details"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -74,14 +74,14 @@ const Details = (props: { node_id: types.TNodeId }) => {
           ))}
         </select>
         <button
-          className="btn-icon"
+          className="btn-icon" aria-label="Show details" title="Show details"
           onClick={handle_add_parents}
           onDoubleClick={utils.prevent_propagation}
         >
           Parents
         </button>
         <button
-          className="btn-icon"
+          className="btn-icon" aria-label="Show details" title="Show details"
           onClick={handle_add_children}
           onDoubleClick={utils.prevent_propagation}
         >
@@ -108,7 +108,7 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   }, [dispatch, props.node_id]);
   return (
     <button
-      className="btn-icon"
+      className="btn-icon" aria-label="Show details" title="Show details"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -14,7 +14,7 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
-      className="btn-icon"
+      className="btn-icon" aria-label="Start" title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -14,7 +14,9 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
-      className="btn-icon" aria-label="Start" title="Start"
+      className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -14,7 +14,9 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
-      className="btn-icon" aria-label="Start concurrent" title="Start concurrent"
+      className="btn-icon"
+      aria-label="Start concurrent"
+      title="Start concurrent"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -14,7 +14,7 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
-      className="btn-icon"
+      className="btn-icon" aria-label="Start concurrent" title="Start concurrent"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      aria-label="Stop"
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -15,7 +15,7 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
-      className="btn-icon"
+      className="btn-icon" aria-label="Mark as done" title="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -15,7 +15,9 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
-      className="btn-icon" aria-label="Mark as done" title="Mark as done"
+      className="btn-icon"
+      aria-label="Mark as done"
+      title="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -15,7 +15,9 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
-      className="btn-icon" aria-label="Mark as won't do" title="Mark as won't do"
+      className="btn-icon"
+      aria-label="Mark as won't do"
+      title="Mark as won't do"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -15,7 +15,7 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
-      className="btn-icon"
+      className="btn-icon" aria-label="Mark as won't do" title="Mark as won't do"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -12,7 +12,9 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
-      className="btn-icon" aria-label="Move to top" title="Move to top"
+      className="btn-icon"
+      aria-label="Move to top"
+      title="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -12,7 +12,7 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
-      className="btn-icon"
+      className="btn-icon" aria-label="Move to top" title="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -4,40 +4,128 @@ export const MINUTE = 60 * 1_000;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
 
-export const DELETE_MARK = <span className="material-icons" aria-hidden="true">close</span>;
+export const DELETE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    close
+  </span>
+);
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons" aria-hidden="true">play_arrow</span>;
+export const START_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    play_arrow
+  </span>
+);
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons" aria-hidden="true">double_arrow</span>
+  <span className="material-icons" aria-hidden="true">
+    double_arrow
+  </span>
 );
-export const ADD_MARK = <span className="material-icons" aria-hidden="true">add</span>;
-export const DONE_MARK = <span className="material-icons" aria-hidden="true">done</span>;
-export const DONT_MARK = <span className="material-icons" aria-hidden="true">delete</span>;
-export const DETAIL_MARK = <span className="material-icons" aria-hidden="true">more_vert</span>;
-export const COPY_MARK = <span className="material-icons" aria-hidden="true">content_copy</span>;
-export const STOP_MARK = <span className="material-icons" aria-hidden="true">stop</span>;
-export const TOP_MARK = <span className="material-icons" aria-hidden="true">arrow_upward</span>;
-export const UNDO_MARK = <span className="material-icons" aria-hidden="true">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons" aria-hidden="true">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons" aria-hidden="true">south</span>;
-export const EVAL_MARK = <span className="material-icons" aria-hidden="true">functions</span>;
-export const TOC_MARK = <span className="material-icons" aria-hidden="true">toc</span>;
+export const ADD_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    add
+  </span>
+);
+export const DONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    done
+  </span>
+);
+export const DONT_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    delete
+  </span>
+);
+export const DETAIL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    more_vert
+  </span>
+);
+export const COPY_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_copy
+  </span>
+);
+export const STOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    stop
+  </span>
+);
+export const TOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_upward
+  </span>
+);
+export const UNDO_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    undo
+  </span>
+);
+export const MOVE_UP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    north
+  </span>
+);
+export const MOVE_DOWN_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    south
+  </span>
+);
+export const EVAL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    functions
+  </span>
+);
+export const TOC_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    toc
+  </span>
+);
 export const FORWARD_MARK = (
-  <span className="material-icons" aria-hidden="true">arrow_forward_ios</span>
+  <span className="material-icons" aria-hidden="true">
+    arrow_forward_ios
+  </span>
 );
-export const BACK_MARK = <span className="material-icons" aria-hidden="true">arrow_back_ios</span>;
-export const SEARCH_MARK = <span className="material-icons" aria-hidden="true">search</span>;
-export const IDS_MARK = <span className="material-icons" aria-hidden="true">content_paste</span>;
-export const MOBILE_MARK = <span className="material-icons" aria-hidden="true">smartphone</span>;
+export const BACK_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_back_ios
+  </span>
+);
+export const SEARCH_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    search
+  </span>
+);
+export const IDS_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_paste
+  </span>
+);
+export const MOBILE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    smartphone
+  </span>
+);
 export const DESKTOP_MARK = (
-  <span className="material-icons" aria-hidden="true">desktop_windows</span>
+  <span className="material-icons" aria-hidden="true">
+    desktop_windows
+  </span>
 );
-export const IS_FULL_MARK = <span className="material-icons" aria-hidden="true">expand_more</span>;
-export const IS_NONE_MARK = <span className="material-icons" aria-hidden="true">expand_less</span>;
+export const IS_FULL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_more
+  </span>
+);
+export const IS_NONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_less
+  </span>
+);
 export const IS_PARTIAL_MARK = (
-  <span className="material-icons" aria-hidden="true">chevron_right</span>
+  <span className="material-icons" aria-hidden="true">
+    chevron_right
+  </span>
 );
 
 export const SPINNER = (

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -4,40 +4,40 @@ export const MINUTE = 60 * 1_000;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
 
-export const DELETE_MARK = <span className="material-icons">close</span>;
+export const DELETE_MARK = <span className="material-icons" aria-hidden="true">close</span>;
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
+export const START_MARK = <span className="material-icons" aria-hidden="true">play_arrow</span>;
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons">double_arrow</span>
+  <span className="material-icons" aria-hidden="true">double_arrow</span>
 );
-export const ADD_MARK = <span className="material-icons">add</span>;
-export const DONE_MARK = <span className="material-icons">done</span>;
-export const DONT_MARK = <span className="material-icons">delete</span>;
-export const DETAIL_MARK = <span className="material-icons">more_vert</span>;
-export const COPY_MARK = <span className="material-icons">content_copy</span>;
-export const STOP_MARK = <span className="material-icons">stop</span>;
-export const TOP_MARK = <span className="material-icons">arrow_upward</span>;
-export const UNDO_MARK = <span className="material-icons">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons">south</span>;
-export const EVAL_MARK = <span className="material-icons">functions</span>;
-export const TOC_MARK = <span className="material-icons">toc</span>;
+export const ADD_MARK = <span className="material-icons" aria-hidden="true">add</span>;
+export const DONE_MARK = <span className="material-icons" aria-hidden="true">done</span>;
+export const DONT_MARK = <span className="material-icons" aria-hidden="true">delete</span>;
+export const DETAIL_MARK = <span className="material-icons" aria-hidden="true">more_vert</span>;
+export const COPY_MARK = <span className="material-icons" aria-hidden="true">content_copy</span>;
+export const STOP_MARK = <span className="material-icons" aria-hidden="true">stop</span>;
+export const TOP_MARK = <span className="material-icons" aria-hidden="true">arrow_upward</span>;
+export const UNDO_MARK = <span className="material-icons" aria-hidden="true">undo</span>;
+export const MOVE_UP_MARK = <span className="material-icons" aria-hidden="true">north</span>;
+export const MOVE_DOWN_MARK = <span className="material-icons" aria-hidden="true">south</span>;
+export const EVAL_MARK = <span className="material-icons" aria-hidden="true">functions</span>;
+export const TOC_MARK = <span className="material-icons" aria-hidden="true">toc</span>;
 export const FORWARD_MARK = (
-  <span className="material-icons">arrow_forward_ios</span>
+  <span className="material-icons" aria-hidden="true">arrow_forward_ios</span>
 );
-export const BACK_MARK = <span className="material-icons">arrow_back_ios</span>;
-export const SEARCH_MARK = <span className="material-icons">search</span>;
-export const IDS_MARK = <span className="material-icons">content_paste</span>;
-export const MOBILE_MARK = <span className="material-icons">smartphone</span>;
+export const BACK_MARK = <span className="material-icons" aria-hidden="true">arrow_back_ios</span>;
+export const SEARCH_MARK = <span className="material-icons" aria-hidden="true">search</span>;
+export const IDS_MARK = <span className="material-icons" aria-hidden="true">content_paste</span>;
+export const MOBILE_MARK = <span className="material-icons" aria-hidden="true">smartphone</span>;
 export const DESKTOP_MARK = (
-  <span className="material-icons">desktop_windows</span>
+  <span className="material-icons" aria-hidden="true">desktop_windows</span>
 );
-export const IS_FULL_MARK = <span className="material-icons">expand_more</span>;
-export const IS_NONE_MARK = <span className="material-icons">expand_less</span>;
+export const IS_FULL_MARK = <span className="material-icons" aria-hidden="true">expand_more</span>;
+export const IS_NONE_MARK = <span className="material-icons" aria-hidden="true">expand_less</span>;
 export const IS_PARTIAL_MARK = (
-  <span className="material-icons">chevron_right</span>
+  <span className="material-icons" aria-hidden="true">chevron_right</span>
 );
 
 export const SPINNER = (


### PR DESCRIPTION
🎨 Palette: [Accessibility] Add ARIA attributes to icon-only buttons

💡 What:
Added `aria-hidden="true"` to all Material UI ligature icon `<span>` elements in `client/src/consts.tsx` and added `aria-label` and `title` attributes to all icon-only buttons (like `StartButton`, `StopButton`, `AddButton`, etc.) throughout the frontend.

🎯 Why:
To prevent screen readers from incorrectly announcing the underlying ligature text (like "play_arrow" instead of "Start") for Material UI icons. Crucially, hiding the icons from screen readers required adding descriptive `aria-label` attributes to the parent icon-only buttons so that they remain accessible to keyboard and screen reader users. Added `title` for visual users to get helpful hover tooltips.

📸 Before/After:
Before: `<button className="btn-icon"><span className="material-icons">play_arrow</span></button>` (screen reader announces "play arrow button")
After: `<button className="btn-icon" aria-label="Start" title="Start"><span className="material-icons" aria-hidden="true">play_arrow</span></button>` (screen reader announces "Start button")

♿ Accessibility:
Dramatically improves accessibility for screen reader users by properly hiding decorative ligature icons and providing explicit semantic labels for all icon-only buttons in the UI. Ensure hover tooltips are also available for keyboard and mouse users.

---
*PR created automatically by Jules for task [10357927215650724453](https://jules.google.com/task/10357927215650724453) started by @kshramt*