### PR TITLE
⚡ Bolt: Add React.memo to QueueEntry and MobileQueueNode

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,8 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+/** ⚡ Bolt: Memoize list item to prevent O(N) re-renders during scrolling and state updates */
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +30,7 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -18,19 +18,18 @@ import * as utils from "./utils";
 import TopButton from "./TopButton";
 
 /** ⚡ Bolt: Memoize list item to prevent O(N) re-renders during scrolling and state updates */
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Memoize list item to prevent O(N) re-renders during scrolling and state updates */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What**: Wrapped `QueueEntry` and `MobileQueueNode` in `React.memo()`. Added inline `⚡ Bolt` comments explaining the optimization.

🎯 **Why**: When a parent component updates or scrolling triggers state changes (especially in the context of virtualized lists or generic mapping operations), React by default re-renders all child components. In large lists, this causes an O(N) performance bottleneck. `React.memo` effectively skips re-rendering these node components entirely when their `node_id` / `nodeId` and `index` props remain unchanged.

📊 **Impact**: Reduces unnecessary render cycles significantly during active scrolling or independent state modifications in parent components, optimizing main-thread CPU usage and improving layout calculation speeds for the application.

🔬 **Measurement**: Verify by using React DevTools Profiler while interacting with queue elements. Observe that `QueueEntry` and `MobileQueueNode` nodes do not re-render unless explicitly interacting with them or modifying their core prop identifiers.

---
*PR created automatically by Jules for task [6509736056231459725](https://jules.google.com/task/6509736056231459725) started by @kshramt*