### PR TITLE
⚡ Bolt: [performance improvement] Memoize list components

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,19 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Wrap with React.memo to prevent unnecessary O(N) re-renders during scrolling and state updates within virtualized lists. */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Wrap with React.memo to prevent unnecessary O(N) re-renders within mapped arrays. */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;

--- a/client/src/swapper.ts
+++ b/client/src/swapper.ts
@@ -1,9 +1,8 @@
 export type TSwapped<K1 extends PropertyKey, Data> = Partial<{
   [k2 in keyof Data]: { [k1 in K1]: Data[k2] };
 }>;
-export type TSwapped1<R> = R extends Record<infer K1, infer Data>
-  ? TSwapped<K1, Data>
-  : never;
+export type TSwapped1<R> =
+  R extends Record<infer K1, infer Data> ? TSwapped<K1, Data> : never;
 
 export const add = <K1 extends PropertyKey, Data extends object>(
   x: Record<K1, Data>,

--- a/client/src/swapper.ts
+++ b/client/src/swapper.ts
@@ -1,8 +1,9 @@
 export type TSwapped<K1 extends PropertyKey, Data> = Partial<{
   [k2 in keyof Data]: { [k1 in K1]: Data[k2] };
 }>;
-export type TSwapped1<R> =
-  R extends Record<infer K1, infer Data> ? TSwapped<K1, Data> : never;
+export type TSwapped1<R> = R extends Record<infer K1, infer Data>
+  ? TSwapped<K1, Data>
+  : never;
 
 export const add = <K1 extends PropertyKey, Data extends object>(
   x: Record<K1, Data>,


### PR DESCRIPTION
💡 **What**: Added `React.memo()` wrapper to `QueueEntry` and `MobileQueueNode` frontend list components.
🎯 **Why**: When parent components (like virtualized lists or main containers) re-render due to state changes, child list nodes that receive pure primitive props (`node_id`, `nodeId`, `index`) do not need to re-render. Since `React.memo` does a shallow comparison of props, it easily skips rendering these unchanged components.
📊 **Impact**: Prevents unnecessary O(N) re-renders across the large virtualized queues and mapped queues during scroll and fast state updates.
🔬 **Measurement**: Verify via React DevTools Profiler by recording scrolling and queue interactions; `QueueEntry` nodes will correctly bypass rendering updates. Tested with locally validated build scripts (`client/scripts/check.sh`).

---
*PR created automatically by Jules for task [16881587547684249727](https://jules.google.com/task/16881587547684249727) started by @kshramt*