### PR TITLE
⚡ Bolt: [performance improvement] Memoize list items to prevent O(N) re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-06 - Prevent O(N) re-renders in virtualized/mapped list items
+**Learning:** List item components receiving primitive props like `node_id` and `index` (e.g., `QueueEntry`, `MobileQueueNode`) cause unnecessary O(N) re-renders during scrolling and state updates within `react-virtuoso` virtualized lists or mapped arrays if not memoized.
+**Action:** Always wrap list item components that take primitive props with `React.memo` when rendering them inside mapped arrays or virtualized lists like `react-virtuoso` to avoid performance bottlenecks.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,8 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+/** ⚡ Bolt: Memoize QueueEntry to prevent O(N) re-renders during scrolling in react-virtuoso */
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +30,7 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -18,19 +18,18 @@ import * as utils from "./utils";
 import TopButton from "./TopButton";
 
 /** ⚡ Bolt: Memoize QueueEntry to prevent O(N) re-renders during scrolling in react-virtuoso */
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Memoize MobileQueueNode to prevent O(N) re-renders in mapped arrays */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What**: Added `React.memo()` to `QueueEntry` and `MobileQueueNode` components.
🎯 **Why**: When mapping arrays or rendering virtualized lists (like `react-virtuoso`), child components that accept primitive props (like `node_id`, `index`) can cause expensive O(N) re-renders across the entire list whenever unrelated states update or the user scrolls. Memoizing these components stops this cascade.
📊 **Impact**: Prevents unnecessary re-renders of list items in the main queue and mobile view, reducing React's reconciliation overhead during scroll/state changes and keeping the main thread free.
🔬 **Measurement**: React DevTools Profiler will show reduced re-render times for list items during scroll events. Tests and lint checks have been run and passed to ensure functionality is identical.

---
*PR created automatically by Jules for task [13825576724916008299](https://jules.google.com/task/13825576724916008299) started by @kshramt*