### PR TITLE
⚡ Bolt: [performance improvement] Add React.memo to QueueEntry and MobileQueueNode

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-07 - Add React.memo to Queue Entries
+**Learning:** Wrapping virtualized or long list item components (`QueueEntry`, `MobileQueueNode`) that receive primitive props (`node_id`, `index`, `nodeId`) in `React.memo` effectively prevents unnecessary O(N) re-renders during state updates or scrolling. This is specifically relevant for `react-virtuoso` lists in the frontend architecture.
+**Action:** Always wrap frequently rendered list entry components with primitive props in `React.memo` to safeguard rendering performance.

--- a/client/dev-dist/registerSW.js
+++ b/client/dev-dist/registerSW.js
@@ -1,0 +1,1 @@
+if('serviceWorker' in navigator) navigator.serviceWorker.register('/dev-sw.js?dev-sw', { scope: '/', type: 'classic' })

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -134,4 +134,4 @@ const TodoQueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
     </>
   );
 };
-QueueEntry.displayName = 'QueueEntry';
+QueueEntry.displayName = "QueueEntry";

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,19 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Wrap QueueEntry in React.memo to prevent unnecessary O(N) re-renders during scrolling in virtualized lists. */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =
@@ -134,3 +134,4 @@ const TodoQueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
     </>
   );
 };
+QueueEntry.displayName = 'QueueEntry';

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Wrap MobileQueueNode in React.memo to prevent unnecessary O(N) re-renders during state updates. */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,7 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;
@@ -1566,3 +1567,4 @@ const get_toggle = utils.memoize1(
   (set: (fn: typeof _toggle) => void) => () => set(_toggle),
 );
 const _toggle = (x: boolean) => !x;
+MobileQueueNode.displayName = 'MobileQueueNode';

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1567,4 +1567,4 @@ const get_toggle = utils.memoize1(
   (set: (fn: typeof _toggle) => void) => () => set(_toggle),
 );
 const _toggle = (x: boolean) => !x;
-MobileQueueNode.displayName = 'MobileQueueNode';
+MobileQueueNode.displayName = "MobileQueueNode";


### PR DESCRIPTION
💡 **What:** Wrapped `QueueEntry` and `MobileQueueNode` components in `React.memo` and assigned explicitly their `displayName`s.
🎯 **Why:** These components receive primitive props (`node_id`, `index`, `nodeId`) and are rendered inside of mapped arrays and `react-virtuoso` virtualized lists. When the parent component re-renders (e.g. from state updates globally or scroll events), these list items undergo unnecessary O(N) re-renders. Wrapping them in `React.memo` effectively memoizes their rendering to only occur when their direct primitive props change.
📊 **Impact:** Significantly reduces frontend CPU usage and unneeded DOM diffing during scrolling or task manipulations. Expected to minimize main thread blocking for long lists.
🔬 **Measurement:** Use React DevTools Profiler to record scrolling/updates before and after this PR. Notice that the gray "Did not render" boxes now apply to unchanged `QueueEntry` components instead of triggering continuous re-evaluation.

---
*PR created automatically by Jules for task [7950079411602669358](https://jules.google.com/task/7950079411602669358) started by @kshramt*