### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move up"
+      title="Move up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +79,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move down"
+      title="Move down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to top"
+      title="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -8,20 +8,40 @@ export const DELETE_MARK = <span className="material-icons">close</span>;
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons" aria-hidden="true">play_arrow</span>;
+export const START_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    play_arrow
+  </span>
+);
 export const START_CONCURRNET_MARK = (
   <span className="material-icons">double_arrow</span>
 );
-export const ADD_MARK = <span className="material-icons" aria-hidden="true">add</span>;
+export const ADD_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    add
+  </span>
+);
 export const DONE_MARK = <span className="material-icons">done</span>;
 export const DONT_MARK = <span className="material-icons">delete</span>;
 export const DETAIL_MARK = <span className="material-icons">more_vert</span>;
 export const COPY_MARK = <span className="material-icons">content_copy</span>;
 export const STOP_MARK = <span className="material-icons">stop</span>;
-export const TOP_MARK = <span className="material-icons" aria-hidden="true">arrow_upward</span>;
+export const TOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_upward
+  </span>
+);
 export const UNDO_MARK = <span className="material-icons">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons" aria-hidden="true">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons" aria-hidden="true">south</span>;
+export const MOVE_UP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    north
+  </span>
+);
+export const MOVE_DOWN_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    south
+  </span>
+);
 export const EVAL_MARK = <span className="material-icons">functions</span>;
 export const TOC_MARK = <span className="material-icons">toc</span>;
 export const FORWARD_MARK = (

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -8,20 +8,20 @@ export const DELETE_MARK = <span className="material-icons">close</span>;
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
+export const START_MARK = <span className="material-icons" aria-hidden="true">play_arrow</span>;
 export const START_CONCURRNET_MARK = (
   <span className="material-icons">double_arrow</span>
 );
-export const ADD_MARK = <span className="material-icons">add</span>;
+export const ADD_MARK = <span className="material-icons" aria-hidden="true">add</span>;
 export const DONE_MARK = <span className="material-icons">done</span>;
 export const DONT_MARK = <span className="material-icons">delete</span>;
 export const DETAIL_MARK = <span className="material-icons">more_vert</span>;
 export const COPY_MARK = <span className="material-icons">content_copy</span>;
 export const STOP_MARK = <span className="material-icons">stop</span>;
-export const TOP_MARK = <span className="material-icons">arrow_upward</span>;
+export const TOP_MARK = <span className="material-icons" aria-hidden="true">arrow_upward</span>;
 export const UNDO_MARK = <span className="material-icons">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons">south</span>;
+export const MOVE_UP_MARK = <span className="material-icons" aria-hidden="true">north</span>;
+export const MOVE_DOWN_MARK = <span className="material-icons" aria-hidden="true">south</span>;
 export const EVAL_MARK = <span className="material-icons">functions</span>;
 export const TOC_MARK = <span className="material-icons">toc</span>;
 export const FORWARD_MARK = (


### PR DESCRIPTION
💡 **What**: Added `aria-hidden="true"` to Material Icon spans in `consts.tsx` and added `aria-label` and `title` attributes to icon-only buttons like `AddButton`, `StartButton`, `TopButton`, `MoveUpButton`, and `MoveDownButton`.

🎯 **Why**: Sighted users recognize buttons via their icons, but screen readers require accessible names to announce buttons properly. Without `aria-hidden="true"` on the icon element and `aria-label` on the button, screen readers may unpredictably read out the material icon font's ligature text (e.g., "play arrow") instead of the intent, causing confusion. `title` provides a helpful tooltip for sighted users.

📸 **Before/After**: Visually identical, but the DOM now includes proper `aria-label` attributes on button nodes.

♿ **Accessibility**: Buttons are now properly identified by screen readers, resolving an accessibility flaw and meeting standard UX practices.

---
*PR created automatically by Jules for task [16209217493314333185](https://jules.google.com/task/16209217493314333185) started by @kshramt*