### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2023-10-27 - Added Missing Security Headers to API
+**Vulnerability:** The `api_v2` backend service lacked standard security headers such as `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`. This could leave the application open to various classes of attacks like Clickjacking, Cross-Site Scripting (XSS), and MIME-sniffing.
+**Learning:** Testing middleware (e.g., security headers) in `api_v2` without a running database is best achieved by targeting a non-existent route (e.g., `/api/v2/not-found`). This triggers the 404 handler and middleware stack without executing database queries that would fail with `connect_lazy`.
+**Prevention:** Always implement standard security headers middleware globally using `tower_http::set_header::SetResponseHeaderLayer` in Axum router setups. Ensure router initialization is decoupled into an `app()` function that allows for easy service layer testing.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,39 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: std::sync::Arc<AppState>) -> axum::Router {
+    use hyper::header::{
+        CONTENT_SECURITY_POLICY, REFERRER_POLICY, STRICT_TRANSPORT_SECURITY, X_CONTENT_TYPE_OPTIONS,
+    };
+    use hyper::http::HeaderValue;
+
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        STRICT_TRANSPORT_SECURITY,
+        HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::HeaderName::from_static("x-frame-options"),
+        HeaderValue::from_static("DENY"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        REFERRER_POLICY,
+        HeaderValue::from_static("no-referrer"),
+    ))
+    .layer(tower_http::trace::TraceLayer::new_for_http())
+    .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +418,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +428,48 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+        let state = std::sync::Arc::new(AppState::new(0, pool));
+        let router = app(state);
+
+        let request = Request::builder()
+            .uri("/api/v2/not-found")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get(hyper::header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers
+                .get(hyper::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(
+            headers.get(hyper::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            headers.get(hyper::header::REFERRER_POLICY).unwrap(),
+            "no-referrer"
+        );
+    }
 }


### PR DESCRIPTION
## 🛡️ Sentinel: [security improvement] Add security headers to API

### Details
* **🚨 Severity:** MEDIUM
* **💡 Vulnerability:** The `api_v2` backend service lacked standard security headers (`Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), potentially leaving the application vulnerable to Clickjacking, XSS, and MIME-sniffing.
* **🎯 Impact:** Browsers interacting with the API might incorrectly interpret responses or frame them maliciously.
* **🔧 Fix:** Extracted the Axum router into an `app()` function and applied `SetResponseHeaderLayer` middleware to inject the necessary headers. Added an inline test suite to verify the headers without requiring a live database.
* **✅ Verification:** Run `cargo test` in `api_v2` and verify the `test_security_headers` test passes. Backend and frontend linting/formatting tests all pass successfully.

---
*PR created automatically by Jules for task [9111303501069492611](https://jules.google.com/task/9111303501069492611) started by @kshramt*