### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-01 - Missing accessible names for icon-only buttons
+**Learning:** Material UI icon spans (e.g., `<span className="material-icons">`) often rely on ligature text (like "add" or "close"), which screen readers will announce confusingly. Merely wrapping these in a `<button className="btn-icon">` without an `aria-label` leaves them opaque or poorly labeled to assistive technologies.
+**Action:** Always ensure decorative/ligature icon spans have `aria-hidden="true"`, and simultaneously ensure their interactive parent elements (like `<button>`) have a clear, descriptive `aria-label` attribute.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -27,6 +27,7 @@ export const AddButton = (props: {
   }, [props.node_id, dispatch, show_mobile, prefix]);
   return (
     <button
+      aria-label="Add"
       className="btn-icon"
       id={props.id}
       onClick={handle_click}

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -22,6 +22,7 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   );
   return (
     <button
+      aria-label="Copy node ID"
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -13,6 +13,7 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Revert to To Do"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -57,6 +57,7 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move up"
       className="btn-icon"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
@@ -76,6 +77,7 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move down"
       className="btn-icon"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -14,6 +14,7 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Evaluate"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/Header/MenuButton/index.tsx
+++ b/client/src/Header/MenuButton/index.tsx
@@ -50,7 +50,9 @@ const MenuButton = (props: {
           onClick={handleButtonClick}
           className="btn-icon"
         >
-          <span className="material-icons">menu</span>
+          <span className="material-icons" aria-hidden="true">
+            menu
+          </span>
         </button>
       </Menu.Target>
 

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -14,6 +14,7 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -14,6 +14,7 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start concurrently"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -15,6 +15,7 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Mark as Done"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -15,6 +15,7 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Mark as Don't"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/ToggleButton/index.tsx
+++ b/client/src/ToggleButton/index.tsx
@@ -18,6 +18,7 @@ const ToggleButton = (props: {
   }, [setValue]);
   return (
     <button
+      aria-label="Toggle"
       className="btn-icon"
       onClick={onClick}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TogglePinButton/index.tsx
+++ b/client/src/TogglePinButton/index.tsx
@@ -15,6 +15,7 @@ const TogglePinButton = (props: { node_id: types.TNodeId }) => {
   const is_pinned = pinned_sub_trees.includes(props.node_id);
   return (
     <button
+      aria-label="Toggle pin"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -12,6 +12,7 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Move to top"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -48,11 +48,15 @@ import * as ops from "./ops";
 import * as undoable from "./undoable";
 
 const SCROLL_BACK_TO_TOP_MARK = (
-  <span className="material-icons">vertical_align_top</span>
+  <span className="material-icons" aria-hidden="true">
+    vertical_align_top
+  </span>
 );
 
 const SCROLL_BACK_TO_BOTTOM_MARK = (
-  <span className="material-icons">vertical_align_bottom</span>
+  <span className="material-icons" aria-hidden="true">
+    vertical_align_bottom
+  </span>
 );
 
 const nonTodoQueueNodesRef = React.createRef<Rv.VirtuosoHandle>();
@@ -442,7 +446,9 @@ const Menu = (props: {
         onClick={_redo}
         onDoubleClick={prevent_propagation}
       >
-        <span className="material-icons">redo</span>
+        <span className="material-icons" aria-hidden="true">
+          redo
+        </span>
       </button>
       <Mt.Switch
         checked={sortByCtime}
@@ -1150,7 +1156,9 @@ const MobileMenu = (props: {
         onClick={_redo}
         onDoubleClick={prevent_propagation}
       >
-        <span className="material-icons">redo</span>
+        <span className="material-icons" aria-hidden="true">
+          redo
+        </span>
       </button>
       <Mt.Switch
         checked={show_todo_only}

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -4,40 +4,128 @@ export const MINUTE = 60 * 1_000;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
 
-export const DELETE_MARK = <span className="material-icons">close</span>;
+export const DELETE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    close
+  </span>
+);
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
+export const START_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    play_arrow
+  </span>
+);
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons">double_arrow</span>
+  <span className="material-icons" aria-hidden="true">
+    double_arrow
+  </span>
 );
-export const ADD_MARK = <span className="material-icons">add</span>;
-export const DONE_MARK = <span className="material-icons">done</span>;
-export const DONT_MARK = <span className="material-icons">delete</span>;
-export const DETAIL_MARK = <span className="material-icons">more_vert</span>;
-export const COPY_MARK = <span className="material-icons">content_copy</span>;
-export const STOP_MARK = <span className="material-icons">stop</span>;
-export const TOP_MARK = <span className="material-icons">arrow_upward</span>;
-export const UNDO_MARK = <span className="material-icons">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons">south</span>;
-export const EVAL_MARK = <span className="material-icons">functions</span>;
-export const TOC_MARK = <span className="material-icons">toc</span>;
+export const ADD_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    add
+  </span>
+);
+export const DONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    done
+  </span>
+);
+export const DONT_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    delete
+  </span>
+);
+export const DETAIL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    more_vert
+  </span>
+);
+export const COPY_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_copy
+  </span>
+);
+export const STOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    stop
+  </span>
+);
+export const TOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_upward
+  </span>
+);
+export const UNDO_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    undo
+  </span>
+);
+export const MOVE_UP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    north
+  </span>
+);
+export const MOVE_DOWN_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    south
+  </span>
+);
+export const EVAL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    functions
+  </span>
+);
+export const TOC_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    toc
+  </span>
+);
 export const FORWARD_MARK = (
-  <span className="material-icons">arrow_forward_ios</span>
+  <span className="material-icons" aria-hidden="true">
+    arrow_forward_ios
+  </span>
 );
-export const BACK_MARK = <span className="material-icons">arrow_back_ios</span>;
-export const SEARCH_MARK = <span className="material-icons">search</span>;
-export const IDS_MARK = <span className="material-icons">content_paste</span>;
-export const MOBILE_MARK = <span className="material-icons">smartphone</span>;
+export const BACK_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_back_ios
+  </span>
+);
+export const SEARCH_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    search
+  </span>
+);
+export const IDS_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_paste
+  </span>
+);
+export const MOBILE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    smartphone
+  </span>
+);
 export const DESKTOP_MARK = (
-  <span className="material-icons">desktop_windows</span>
+  <span className="material-icons" aria-hidden="true">
+    desktop_windows
+  </span>
 );
-export const IS_FULL_MARK = <span className="material-icons">expand_more</span>;
-export const IS_NONE_MARK = <span className="material-icons">expand_less</span>;
+export const IS_FULL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_more
+  </span>
+);
+export const IS_NONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_less
+  </span>
+);
 export const IS_PARTIAL_MARK = (
-  <span className="material-icons">chevron_right</span>
+  <span className="material-icons" aria-hidden="true">
+    chevron_right
+  </span>
 );
 
 export const SPINNER = (


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to icon-only buttons (`AddButton`, `StartButton`, `TopButton`, etc.) across the application and updated the base `material-icons` components to include `aria-hidden="true"`.
🎯 **Why**: Icon-only buttons relying purely on icon ligatures (like "add" or "close" inside `material-icons` spans) are extremely poorly named and confusing for assistive technologies. This gives every such button a clear accessible name to assistive technologies.
📸 **Before/After**: N/A (non-visual change)
♿ **Accessibility**: Improves keyboard & screen reader accessibility by ensuring interactive elements provide proper descriptive labels, rather than forcing screen readers to announce confusing icon ligature text.

---
*PR created automatically by Jules for task [1141500549017959586](https://jules.google.com/task/1141500549017959586) started by @kshramt*