### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-10 - Strict Content-Security-Policy with `default-src 'none'`
+**Vulnerability:** Missing strict Content-Security-Policy (CSP) headers inside API.
+**Learning:** `tower_http::set_header::SetResponseHeaderLayer` can inject CSP headers. However, applying a strict `default-src 'none'` completely breaks any HTML endpoints served directly by the API.
+**Prevention:** Apply `default-src 'none'` only if endpoints don't serve HTML or override it on HTML-serving routes.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,34 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::CONTENT_SECURITY_POLICY,
+        axum::http::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::STRICT_TRANSPORT_SECURITY,
+        axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::X_FRAME_OPTIONS,
+        axum::http::HeaderValue::from_static("DENY"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::X_CONTENT_TYPE_OPTIONS,
+        axum::http::HeaderValue::from_static("nosniff"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::REFERRER_POLICY,
+        axum::http::HeaderValue::from_static("no-referrer"),
+    ))
+    .layer(tower_http::trace::TraceLayer::new_for_http())
+    .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +413,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +423,48 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+        let state = std::sync::Arc::new(AppState::new(0, pool));
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri("/api/v2/not-found")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get(hyper::header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers
+                .get(hyper::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(headers.get(hyper::header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            headers.get(hyper::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            headers.get(hyper::header::REFERRER_POLICY).unwrap(),
+            "no-referrer"
+        );
+    }
 }


### PR DESCRIPTION
## 🛡️ Sentinel: [MEDIUM] Add security headers to API

### What
Adds HTTP security headers to all endpoints in the `api_v2` backend.
The middleware injects the following headers:
- `Content-Security-Policy` (default-src 'none'; frame-ancestors 'none'; sandbox)
- `Strict-Transport-Security` (max-age=31536000; includeSubDomains)
- `X-Frame-Options` (DENY)
- `X-Content-Type-Options` (nosniff)
- `Referrer-Policy` (no-referrer)

### Why
Defense in depth. While this is primarily an API backend, missing essential security headers triggers security scanners and misses an opportunity to protect against potential browser-side vulnerabilities (e.g., MIME-sniffing, clickjacking) if clients mishandle responses. 

### Implementation Details
- Extracted `axum::Router` construction into a public `app()` function inside `main.rs` to allow unit testing without spinning up a live TCP server.
- Uses `tower_http::set_header::SetResponseHeaderLayer` for header injection.
- Applied `#[allow(dead_code)]` to auto-generated structs failing `cargo clippy`.
- Wrote an integration test using `tower::ServiceExt::oneshot` and `connect_lazy` to verify headers are applied even when a route is not found.

### Verification
- `cargo test` confirms the headers are correctly applied.
- `cargo check`, `cargo fmt`, and `cargo clippy` pass successfully.

---
*PR created automatically by Jules for task [9957121114951357653](https://jules.google.com/task/9957121114951357653) started by @kshramt*