### PR TITLE
⚡ Bolt: Add React.memo to prevent O(N) re-renders in lists

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Wrapped in React.memo to prevent unnecessary O(N) re-renders within virtualized list. */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Wrapped in React.memo to prevent unnecessary O(N) re-renders in mapped arrays. */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` and `MobileQueueNode` components with `React.memo` and assigned explicitly named `displayName`s.
🎯 Why: These list items receive primitive props (`node_id`, `index`) and exist within large dynamically mapped arrays or virtualized lists (`react-virtuoso`). Without memoization, parent state changes or scroll events force React to re-render every item in the list sequentially, creating an unnecessary O(N) operation and significant main-thread blocking.
📊 Impact: Prevents unnecessary O(N) full-list re-renders in `MobileQueueNodes` and virtualized queue instances when parent component state updates. Will reduce scroll jank and interaction latency on large tree nodes.
🔬 Measurement: Open React Profiler, observe "Commit" timings while scrolling or toggling list item state. Components will now show "Did not render" if their primitive props remain unchanged.

---
*PR created automatically by Jules for task [5973443048855036711](https://jules.google.com/task/5973443048855036711) started by @kshramt*