### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-04-11 - Missing Security Headers in Rust API
+**Vulnerability:** Missing security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) in `api_v2` responses, which could lead to various client-side attacks.
+**Learning:** Axum router does not provide default security headers. You must explicitly configure them using `tower_http::set_header::SetResponseHeaderLayer` and `hyper::header`. Furthermore, testing `api_v2` state initialization requires using `connect_lazy` with a dummy URI if not spinning up the full DB infrastructure.
+**Prevention:** Always include a default set of security headers via tower middleware for any new web APIs written in Axum to ensure defense in depth, and utilize integration tests to verify middleware.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,36 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: std::sync::Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::REFERRER_POLICY,
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +415,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +425,49 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+        let state = std::sync::Arc::new(AppState::new(0, pool));
+        let router = app(state);
+
+        let req = Request::builder()
+            .uri("/api/v2/not-found")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = router.oneshot(req).await.unwrap();
+
+        let headers = response.headers();
+        assert_eq!(
+            headers.get(hyper::header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers
+                .get(hyper::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(headers.get(hyper::header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            headers.get(hyper::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            headers.get(hyper::header::REFERRER_POLICY).unwrap(),
+            "no-referrer"
+        );
+    }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) in `api_v2` responses, which could leave the API vulnerable to clickjacking, mime-sniffing, and other client-side attacks.
🎯 Impact: Attackers could potentially exploit the lack of headers to perform clickjacking or downgrade attacks if responses are ever served directly to browsers or framed.
🔧 Fix: Extracted the main `axum::Router` initialization logic into a `pub fn app(state: Arc<AppState>) -> axum::Router` function. Wrapped the router with `tower_http::set_header::SetResponseHeaderLayer` middleware to enforce `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`. Wrote an integration test using `tower::ServiceExt::oneshot` to verify the presence of the headers.
✅ Verification: Ensure the test passes by running `cd api_v2 && cargo test`. You can verify the headers locally by running the server and sending a GET request (e.g., `curl -I http://localhost:8080/`).

---
*PR created automatically by Jules for task [14465292048311371322](https://jules.google.com/task/14465292048311371322) started by @kshramt*