### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and tooltips to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - Adding ARIA labels to icon-only buttons
+**Learning:** Found that some primary action buttons (like Add and Start) were missing accessible names, rendering them silent for screen reader users, despite visually communicating intent via icons.
+**Action:** Always ensure icon-only buttons (`<button className="btn-icon">`) include `aria-label` (for screen readers) and `title` (for mouse hover tooltips).

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,8 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add"
+      title="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to `StartButton` and `AddButton` components.
🎯 Why: These icon-only buttons were lacking accessible names, making them difficult for screen reader users to understand. The tooltips also help mouse users who might not recognize the icons immediately.
♿ Accessibility: Improved screen reader support by giving interactive elements descriptive names.

---
*PR created automatically by Jules for task [10011300002050904699](https://jules.google.com/task/10011300002050904699) started by @kshramt*