### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-18 - Set Security Headers Middlewares in `api_v2`
+**Vulnerability:** Missing strict security response headers in the API service.
+**Learning:** Security headers (like `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`) can be effectively applied across all routes using `tower_http::set_header::SetResponseHeaderLayer` in the Axum framework. `hyper::header` must be imported to configure valid header names. Extracting the `app` generation function simplifies running non-live router tests using `oneshot`.
+**Prevention:** Integrate a shared configuration function for standard `tower_http` security middleware in future rust web services to guarantee all responses (including 404s/errors) receive secure headers.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -33,6 +33,7 @@ pub struct FakeIdpCreateUserRequest {
 pub struct FakeIdpCreateUserResponse {
     pub id_token: IdToken,
 }
+#[allow(dead_code)]
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct FakeIdpCreateIdTokenRequest {

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -8,11 +8,13 @@ use axum_extra::{
     TypedHeader,
 };
 use base64::Engine;
+use hyper::header;
 use serde_json::json;
 use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
@@ -338,9 +340,9 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
-    id_generator: Mutex<id_generator::SortableIdGenerator>,
-    pool: sqlx::postgres::PgPool,
+pub struct AppState {
+    pub id_generator: Mutex<id_generator::SortableIdGenerator>,
+    pub pool: sqlx::postgres::PgPool,
 }
 impl AppState {
     pub fn new(shard: u16, pool: sqlx::postgres::PgPool) -> Self {
@@ -378,6 +380,36 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +417,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +427,49 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        // Use a dummy connection string that will lazy connect to not fail on creation without db
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+
+        let state = std::sync::Arc::new(AppState::new(0, pool));
+        let app = app(state);
+
+        // Test against a non-existent route to avoid hitting db query logic
+        let req = Request::builder()
+            .uri("/api/v2/not-found")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(req).await.unwrap();
+
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get(hyper::header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers
+                .get(hyper::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(headers.get(hyper::header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            headers.get(hyper::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(headers.get("referrer-policy").unwrap(), "no-referrer");
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

### 🚨 Severity
MEDIUM

### 💡 Vulnerability
The `api_v2` Rust service was missing strict security response headers, potentially leaving clients consuming the API exposed to various web vulnerabilities depending on context (e.g. framing, MIME-sniffing). 

### 🎯 Impact
Without these headers, clients interacting with the API might be susceptible to Cross-Site Scripting (XSS), Clickjacking, and MIME-sniffing attacks. Enforcing them adds a crucial layer of defense-in-depth across all JSON responses.

### 🔧 Fix
- Extracted the Axum router setup in `api_v2/src/main.rs` into a standalone `app` function.
- Implemented `tower_http::set_header::SetResponseHeaderLayer` to override default headers on all routes.
- Applied `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; sandbox`.
- Applied `Strict-Transport-Security: max-age=31536000; includeSubDomains`.
- Applied `X-Frame-Options: DENY`.
- Applied `X-Content-Type-Options: nosniff`.
- Applied `Referrer-Policy: no-referrer`.

### ✅ Verification
- All backend unit tests in `api_v2` compile and pass cleanly via `cargo test`.
- Added a specific test `test_security_headers` that asserts these exact headers are present using the simulated `oneshot` router.
- Cleaned up clippy dead-code warnings in `api_v2/src/gen.rs`.
- Checked frontend pipelines via `./scripts/check.sh`.

---
*PR created automatically by Jules for task [14592510374092489526](https://jules.google.com/task/14592510374092489526) started by @kshramt*