### PR TITLE
🎨 Palette: Add accessible labels to Start buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-13 - Icon-only buttons lacking ARIA labels
+**Learning:** Many icon-only buttons (`.btn-icon`) in `client/src/` use Material UI ligature icons (e.g. `<span className="material-icons">add</span>`) but lack `aria-label` or `title` attributes on the parent `<button>`. This causes screen readers to either read the ligature text ("add") poorly or nothing at all if aria-hidden is applied to the span. It also means users without screen readers don't get tooltips to explain the button's purpose.
+**Action:** Always verify that buttons containing only an icon component or ligature text have an explicit `aria-label` and `title` attribute explaining the action.

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrently"
+      title="Start concurrently"
     >
       {consts.START_CONCURRNET_MARK}
     </button>

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -8,9 +8,15 @@ export const DELETE_MARK = <span className="material-icons">close</span>;
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
+export const START_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    play_arrow
+  </span>
+);
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons">double_arrow</span>
+  <span className="material-icons" aria-hidden="true">
+    double_arrow
+  </span>
 );
 export const ADD_MARK = <span className="material-icons">add</span>;
 export const DONE_MARK = <span className="material-icons">done</span>;


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to the Start and Start Concurrent buttons, and added `aria-hidden="true"` to the corresponding material icon spans.
🎯 Why: Ligature icons without explicit ARIA labels are inaccessible to screen reader users (who hear the ligature text, e.g., "play_arrow", instead of the button's action) and lack hover tooltips for visual users.
📸 Before/After: Before, buttons had no tooltip and screen readers read "play arrow". After, buttons have a "Start" or "Start concurrently" tooltip and screen readers read the correct action.
♿ Accessibility: Improved screen reader support by providing explicit accessible names to icon-only buttons.

---
*PR created automatically by Jules for task [5638392080156260771](https://jules.google.com/task/5638392080156260771) started by @kshramt*