### PR TITLE
⚡ Bolt: [performance improvement] Memoize virtualized queue node items to prevent O(N) re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-13 - Optimize list item components in virtualized lists
+**Learning:** List item components in virtualized lists (like `react-virtuoso`) or mapped arrays (like in `QueueEntry` and `MobileQueueNode`) that receive simple primitive props (like `node_id` and `index`) are prone to unnecessary O(N) re-renders during scrolling and state updates if not properly memoized.
+**Action:** When adding or maintaining item components for lists/queues, use `React.memo()` to prevent expensive and unnecessary re-renders, and ensure to attach `.displayName` for readability in React DevTools.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,21 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Memoize QueueEntry to prevent O(N) re-renders during virtualized list scrolling and state updates */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Memoize MobileQueueNode to prevent O(N) re-renders during mapping and state updates */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,9 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` and `MobileQueueNode` components with `React.memo` and assigned them `displayName`s.
🎯 Why: These list item components receive primitive props (`node_id` and `index`) and render frequently in large virtualized lists (`react-virtuoso`) or mapped arrays. Without memoization, they trigger unnecessary O(N) re-renders every time their parent components or global states change.
📊 Impact: Eliminates O(N) render cycle costs for queue lists during scrolling and state updates, drastically reducing the main thread blocking time.
🔬 Measurement: Verified with `pnpm build` and the full test suite (`./scripts/check.sh` and Axum backend checks). Playwright visual scripts confirm correct layout mapping.

---
*PR created automatically by Jules for task [3411402052122305242](https://jules.google.com/task/3411402052122305242) started by @kshramt*