### PR TITLE
⚡ Bolt: [performance improvement] Memoize QueueEntry and MobileQueueNode list components

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,23 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/**
+ * ⚡ Bolt: Wrap QueueEntry in React.memo to prevent O(N) re-renders during scrolling and
+ * state updates within react-virtuoso virtualized lists or mapped arrays.
+ */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,11 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/**
+ * ⚡ Bolt: Wrap MobileQueueNode in React.memo to prevent O(N) re-renders
+ * during state updates within the mapped array.
+ */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1239,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What:** Wrapped the `QueueEntry` (in `client/src/QueueEntry.tsx`) and `MobileQueueNode` (in `client/src/components.tsx`) components in `React.memo()`. Also assigned standard `displayName`s to both to keep React DevTools debuggable. 
🎯 **Why:** Both components are heavily repeated within virtualized lists (like `react-virtuoso`) or mapped arrays and they receive simple primitive props (like `node_id` and `index`). Without memoization, they re-render unnecessarily whenever their parent list updates, triggering an O(N) performance bottleneck.
📊 **Impact:** Reduces O(N) re-renders for list components on scroll, state mutations, and app startup, translating to noticeable drop in CPU main thread blocking and faster list responsiveness.
🔬 **Measurement:** Verify by using React DevTools Profiler while typing into text areas or scrolling through heavily populated tree queues. Look for grayed-out (bypassed) renders for siblings of the updated queue item.

---
*PR created automatically by Jules for task [12741687812085722822](https://jules.google.com/task/12741687812085722822) started by @kshramt*