### PR TITLE
🛡️ Sentinel: [MEDIUM] Add API security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2023-10-27 - Missing Security Headers on API Endpoints
+**Vulnerability:** The Rust backend (`api_v2`) lacked standard security headers such as `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`.
+**Learning:** These basic headers are crucial for defense-in-depth, protecting API endpoints from common browser-side exploits like XSS, framing attacks, and MIME-sniffing, even if it primarily serves JSON.
+**Prevention:** Ensure the `tower_http::set_header::SetResponseHeaderLayer` middleware is applied globally on Axum routers to enforce these protections on all responses.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -34,6 +34,7 @@ pub struct FakeIdpCreateUserResponse {
     pub id_token: IdToken,
 }
 #[rustfmt::skip]
+#[allow(dead_code)]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,36 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::appending(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::appending(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::appending(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::appending(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::appending(
+            hyper::header::REFERRER_POLICY,
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +415,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +425,48 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use hyper::header;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+        let state = Arc::new(AppState::new(0, pool));
+        let app = app(state);
+
+        let req = Request::builder()
+            .uri("/api/v2/not-found")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let res = app.oneshot(req).await.unwrap();
+
+        assert_eq!(
+            res.headers().get(header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            res.headers()
+                .get(header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(res.headers().get(header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            res.headers().get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            res.headers().get(header::REFERRER_POLICY).unwrap(),
+            "no-referrer"
+        );
+    }
 }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The API endpoints lacked basic security headers like CSP, HSTS, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy. Although it primarily serves JSON, not enforcing these browser policies can theoretically expose the endpoints to clickjacking (if framing is used maliciously) or MIME-sniffing attacks. 
🎯 **Impact:** Browsers interacting with the API might have been tricked into executing malicious contexts if an endpoint accidentally returned HTML or exploitable content.
🔧 **Fix:** Refactored `api_v2/src/main.rs` to extract the router into a standalone `pub fn app()` function. Added a global `tower_http::set_header::SetResponseHeaderLayer` to attach the necessary security headers to every response. Also added a `#[allow(dead_code)]` in the auto-generated `gen.rs` to fix existing strict CI warnings.
✅ **Verification:** Added inline integration tests utilizing `tower::ServiceExt::oneshot` targeting a dummy route `/api/v2/not-found` to assert all five headers are correctly injected without requiring an active database connection. Verified clean compilation and successful test output across `cargo check`, `cargo test`, and `cargo clippy`. Added critical learnings to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [609583471574853548](https://jules.google.com/task/609583471574853548) started by @kshramt*