### PR TITLE
⚡ Bolt: [performance improvement] Memoize list entry components to prevent unnecessary re-renders

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Memoize list entry component to prevent unnecessary O(N) re-renders during scrolling and state updates within virtualized lists */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Memoize list entry component to prevent unnecessary O(N) re-renders during scrolling and state updates within mapped arrays */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What**: Wrapped `QueueEntry` and `MobileQueueNode` components with `React.memo` and set their `displayName`.
🎯 **Why**: Both components receive primitive props (`node_id`/`nodeId`, `index`) and are rendered within mapped arrays or virtualized lists (`react-virtuoso`). Without memoization, they re-render every time the parent component state updates, leading to unnecessary O(N) rendering work.
📊 **Impact**: Reduces unnecessary re-renders in list views significantly, improving scroll performance and responsiveness when state changes occur.
🔬 **Measurement**: Verify by using React DevTools Profiler to observe component rendering while scrolling or dispatching Redux state updates; these components should now skip rendering unless their specific props change.

---
*PR created automatically by Jules for task [12957775130741482831](https://jules.google.com/task/12957775130741482831) started by @kshramt*