### PR TITLE
⚡ Bolt: Optimize list rendering performance using React.memo

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Prevent O(N) re-renders in virtualized list */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Prevent O(N) re-renders in list updates */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What:** Added `React.memo` around `QueueEntry` and `MobileQueueNode` components in the client frontend. Added `displayName` for React DevTools readability.

🎯 **Why:** To prevent unnecessary O(N) re-renders. List item components receiving primitive props (like `node_id` and `index`) do not need to re-render unless their specific props change. When virtualized lists (`react-virtuoso`) scroll or global state triggers parent updates, these components were previously re-rendering on every update, causing performance overhead. 

📊 **Impact:** Reduces React re-renders for list items to O(1) per affected item instead of O(N) for the entire list. This significantly improves scrolling performance and global state update responsiveness, especially for large lists of tasks.

🔬 **Measurement:** Verify by running the frontend test suite (`cd client && ./scripts/check.sh`). Observe fewer renders of `QueueEntry` and `MobileQueueNode` in React DevTools Profiler when interacting with items in the list.

---
*PR created automatically by Jules for task [12536539105749547309](https://jules.google.com/task/12536539105749547309) started by @kshramt*