### PR TITLE
⚡ Bolt: [performance improvement] Memoize Queue Entries to prevent O(N) re-renders

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: memoize QueueEntry to prevent O(N) re-renders during state updates */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: memoize MobileQueueNode to prevent O(N) re-renders during state updates */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What:** Added `React.memo` around `QueueEntry` and `MobileQueueNode` list item components, ensuring they do not redundantly re-render when parent state updates. Included `.displayName` property assignments.
🎯 **Why:** List item components placed inside `react-virtuoso` lists or mapped `queue` slices process primitive props (`node_id`, `index`). Without memoization, any change in the parent triggers re-renders on all list elements, causing thousands of wasted evaluation cycles. 
📊 **Impact:** Reduces O(N) unneeded item component re-renders per UI event (drastic performance savings for 100+ queue nodes in mobile views or virtual scrolling on desktop).
🔬 **Measurement:** Use React DevTools Profiler during state changes (e.g., ticking a todo item done or typing in a node filter) and observe re-rendering scopes limited purely to targeted nodes rather than the entire list chunk.

---
*PR created automatically by Jules for task [4851803746787201392](https://jules.google.com/task/4851803746787201392) started by @kshramt*