### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and tooltips to icon buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add subtask"
+      title="Add subtask"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move up"
+      title="Move up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +79,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move down"
+      title="Move down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 What: Added semantic `aria-label` and `title` attributes to multiple icon-only action buttons across the `client/src` component tree.
🎯 Why: Icon-only buttons without accessible names cannot be read or understood by screen readers, creating a major barrier. Additionally, adding the `title` attribute provides native browser tooltips on hover, helping sighted users understand what the icons do without guessing.
📸 Before/After: Visual presentation is identical (unchanged), but hovering now shows an informative tooltip. Screen reader functionality goes from "button" to "Start", "Add subtask", etc.
♿ Accessibility: Ensures WCAG compliance for interactive elements by giving them clear accessible names. Screen readers will now correctly announce the purpose of these primary action buttons.

---
*PR created automatically by Jules for task [17396570207142200347](https://jules.google.com/task/17396570207142200347) started by @kshramt*