### PR TITLE
🎨 Palette: Improve accessibility for icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,8 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add"
+      title="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Copy Node ID"
+      title="Copy Node ID"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Undo"
+      title="Undo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move up"
+      title="Move up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +79,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move down"
+      title="Move down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -15,6 +15,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Evaluate"
+      title="Evaluate"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/Header/MenuButton/index.tsx
+++ b/client/src/Header/MenuButton/index.tsx
@@ -49,8 +49,12 @@ const MenuButton = (props: {
           ref={menuButtonRef}
           onClick={handleButtonClick}
           className="btn-icon"
+          aria-label="Menu"
+          title="Menu"
         >
-          <span className="material-icons">menu</span>
+          <span className="material-icons" aria-hidden="true">
+            menu
+          </span>
         </button>
       </Menu.Target>
 

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -109,6 +109,8 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Show details"
+      title="Show details"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      aria-label="Stop"
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
+      title="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Delete"
+      title="Delete"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TogglePinButton/index.tsx
+++ b/client/src/TogglePinButton/index.tsx
@@ -16,6 +16,8 @@ const TogglePinButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Toggle pin"
+      title="Toggle pin"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to top"
+      title="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -48,11 +48,15 @@ import * as ops from "./ops";
 import * as undoable from "./undoable";
 
 const SCROLL_BACK_TO_TOP_MARK = (
-  <span className="material-icons">vertical_align_top</span>
+  <span className="material-icons" aria-hidden="true">
+    vertical_align_top
+  </span>
 );
 
 const SCROLL_BACK_TO_BOTTOM_MARK = (
-  <span className="material-icons">vertical_align_bottom</span>
+  <span className="material-icons" aria-hidden="true">
+    vertical_align_bottom
+  </span>
 );
 
 const nonTodoQueueNodesRef = React.createRef<Rv.VirtuosoHandle>();
@@ -442,7 +446,9 @@ const Menu = (props: {
         onClick={_redo}
         onDoubleClick={prevent_propagation}
       >
-        <span className="material-icons">redo</span>
+        <span className="material-icons" aria-hidden="true">
+          redo
+        </span>
       </button>
       <Mt.Switch
         checked={sortByCtime}
@@ -1150,7 +1156,9 @@ const MobileMenu = (props: {
         onClick={_redo}
         onDoubleClick={prevent_propagation}
       >
-        <span className="material-icons">redo</span>
+        <span className="material-icons" aria-hidden="true">
+          redo
+        </span>
       </button>
       <Mt.Switch
         checked={show_todo_only}

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -4,40 +4,128 @@ export const MINUTE = 60 * 1_000;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
 
-export const DELETE_MARK = <span className="material-icons">close</span>;
+export const DELETE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    close
+  </span>
+);
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
+export const START_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    play_arrow
+  </span>
+);
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons">double_arrow</span>
+  <span className="material-icons" aria-hidden="true">
+    double_arrow
+  </span>
 );
-export const ADD_MARK = <span className="material-icons">add</span>;
-export const DONE_MARK = <span className="material-icons">done</span>;
-export const DONT_MARK = <span className="material-icons">delete</span>;
-export const DETAIL_MARK = <span className="material-icons">more_vert</span>;
-export const COPY_MARK = <span className="material-icons">content_copy</span>;
-export const STOP_MARK = <span className="material-icons">stop</span>;
-export const TOP_MARK = <span className="material-icons">arrow_upward</span>;
-export const UNDO_MARK = <span className="material-icons">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons">south</span>;
-export const EVAL_MARK = <span className="material-icons">functions</span>;
-export const TOC_MARK = <span className="material-icons">toc</span>;
+export const ADD_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    add
+  </span>
+);
+export const DONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    done
+  </span>
+);
+export const DONT_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    delete
+  </span>
+);
+export const DETAIL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    more_vert
+  </span>
+);
+export const COPY_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_copy
+  </span>
+);
+export const STOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    stop
+  </span>
+);
+export const TOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_upward
+  </span>
+);
+export const UNDO_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    undo
+  </span>
+);
+export const MOVE_UP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    north
+  </span>
+);
+export const MOVE_DOWN_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    south
+  </span>
+);
+export const EVAL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    functions
+  </span>
+);
+export const TOC_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    toc
+  </span>
+);
 export const FORWARD_MARK = (
-  <span className="material-icons">arrow_forward_ios</span>
+  <span className="material-icons" aria-hidden="true">
+    arrow_forward_ios
+  </span>
 );
-export const BACK_MARK = <span className="material-icons">arrow_back_ios</span>;
-export const SEARCH_MARK = <span className="material-icons">search</span>;
-export const IDS_MARK = <span className="material-icons">content_paste</span>;
-export const MOBILE_MARK = <span className="material-icons">smartphone</span>;
+export const BACK_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_back_ios
+  </span>
+);
+export const SEARCH_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    search
+  </span>
+);
+export const IDS_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_paste
+  </span>
+);
+export const MOBILE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    smartphone
+  </span>
+);
 export const DESKTOP_MARK = (
-  <span className="material-icons">desktop_windows</span>
+  <span className="material-icons" aria-hidden="true">
+    desktop_windows
+  </span>
 );
-export const IS_FULL_MARK = <span className="material-icons">expand_more</span>;
-export const IS_NONE_MARK = <span className="material-icons">expand_less</span>;
+export const IS_FULL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_more
+  </span>
+);
+export const IS_NONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_less
+  </span>
+);
 export const IS_PARTIAL_MARK = (
-  <span className="material-icons">chevron_right</span>
+  <span className="material-icons" aria-hidden="true">
+    chevron_right
+  </span>
 );
 
 export const SPINNER = (


### PR DESCRIPTION
**💡 What:** Added `aria-label` and `title` attributes to all primary icon-only action buttons across the UI (e.g., Start, Add, Undo, Menu) and marked internal Material UI ligature spans with `aria-hidden="true"`.
**🎯 Why:** Screen readers correctly announce the purpose of these icon-only buttons instead of incorrectly reading their internal ligature text (e.g. "play_arrow" or "more_vert"), while desktop users receive helpful tooltips on hover.
**📸 Before/After:** Before: Buttons relied solely on visual icons. After: Full accessible names and title text are provided, and internal layout spans are hidden from assistive technology.
**♿ Accessibility:** Greatly improves screen-reader compatibility and keyboard-navigation clarity by giving critical interaction points descriptive aria-labels.

---
*PR created automatically by Jules for task [7722486486510088210](https://jules.google.com/task/7722486486510088210) started by @kshramt*