### PR TITLE
⚡ Bolt: [performance improvement] Prevent O(N) re-renders in virtualized lists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-19 - Prevent O(N) Re-renders in Virtualized and Mapped Lists
+**Learning:** Virtualized lists and mapped arrays in React can trigger O(N) re-renders if list item components are not memoized, particularly when global state updates cause parent components to re-render. This is especially impactful in large, frequently updating lists.
+**Action:** Wrap primitive list item components (e.g., those accepting only `id` or `index` props) with `React.memo` and ensure their `displayName` is explicitly set to preserve React DevTools readability.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Wrapped list items with React.memo to prevent O(N) re-renders in virtualized lists when unrelated global state changes. */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Wrapped list items with React.memo to prevent O(N) re-renders in mapped lists when unrelated global state changes. */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
### 💡 What:
Wrapped `QueueEntry` and `MobileQueueNode` components with `React.memo()`. Explicitly added `.displayName` to both components to maintain proper names in React DevTools.

### 🎯 Why:
Both components represent individual items within lists (either virtualized via `react-virtuoso` or standard mapped arrays). Previously, whenever the parent list component re-rendered due to unrelated global state changes (e.g., changes to filtered nodes or statuses elsewhere in the tree), all child item components would also re-render unnecessarily because React re-renders descendants by default. Since these components only accept primitive props (`node_id`, `index`), `React.memo` ensures they skip rendering unless those specific props change.

### 📊 Impact:
*   **Significantly reduces unnecessary React render cycles** from O(N) (where N is the number of rendered items in the queue) down to O(1) for isolated updates.
*   Improves perceived scroll performance and responsiveness, especially on mobile devices or in large virtualized lists.

### 🔬 Measurement:
To verify the improvement, you can observe component re-renders using the React DevTools Profiler plugin:
1.  Open React DevTools and start a Profiler session.
2.  Trigger a global state change that causes the parent list to re-render but shouldn't affect most list items.
3.  Observe that `QueueEntry` and `MobileQueueNode` are now reported as "Did not render" rather than re-evaluating.

---
*PR created automatically by Jules for task [12932037404239207419](https://jules.google.com/task/12932037404239207419) started by @kshramt*