### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to core icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-19 - ARIA Labels for Icon-Only Buttons
+**Learning:** React Material UI icon spans (e.g. `<span className="material-icons">`) often don't provide accessible text by themselves when used within interactive elements. When rendering an icon-only button like `<button><span className="material-icons">add</span></button>`, the `button` MUST be explicitly given an `aria-label` attribute (and ideally a `title` for hover tooltips) to be screen-reader accessible.
+**Action:** Always check that any button containing only an icon (especially one rendering just a material-icon string) has a corresponding `aria-label` or `title` explicitly set.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -27,6 +27,8 @@ export const AddButton = (props: {
   }, [props.node_id, dispatch, show_mobile, prefix]);
   return (
     <button
+      aria-label="Add child node"
+      title="Add child node"
       className="btn-icon"
       id={props.id}
       onClick={handle_click}

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -57,6 +57,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move up"
+      title="Move up"
       className="btn-icon"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
@@ -76,6 +78,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move down"
+      title="Move down"
       className="btn-icon"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -14,6 +14,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start"
+      title="Start"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -14,6 +14,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start concurrently"
+      title="Start concurrently"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to `AddButton`, `StartButton`, `StartConcurrentButton`, `MoveUpButton`, and `MoveDownButton` icon-only buttons.
🎯 Why: These buttons rely solely on Material Icon font ligatures and contained no accessible text, making them confusing or invisible to screen readers. Adding tooltips also improves mouse accessibility.
♿ Accessibility: Improved screen reader compliance and keyboard accessibility by giving clear names to the buttons.

---
*PR created automatically by Jules for task [14222397912306325455](https://jules.google.com/task/14222397912306325455) started by @kshramt*