### PR TITLE
⚡ Bolt: [performance improvement] Memoize QueueEntry and MobileQueueNode

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Prevent O(N) Re-renders in Virtualized Lists
+**Learning:** List item components receiving primitive props like `node_id` and `index` (e.g., `QueueEntry`, `MobileQueueNode`) within virtualized lists (like `react-virtuoso` or simple maps) cause O(N) re-renders during scrolling and global state updates unless memoized.
+**Action:** Wrap these list item components in `React.memo` and append `displayName` (e.g., `QueueEntry.displayName = 'QueueEntry';`) to prevent unnecessary re-renders while maintaining React DevTools readability.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,8 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+/** ⚡ Bolt: Wraps list item with React.memo to prevent O(N) re-renders when parent state changes. Reduces render cycle overhead by preventing unchanged items from rendering. */
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +30,8 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -18,19 +18,18 @@ import * as utils from "./utils";
 import TopButton from "./TopButton";
 
 /** ⚡ Bolt: Wraps list item with React.memo to prevent O(N) re-renders when parent state changes. Reduces render cycle overhead by preventing unchanged items from rendering. */
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Wraps list item with React.memo to prevent O(N) re-renders when parent state changes. Reduces render cycle overhead by preventing unchanged items from rendering. */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What**: Added `React.memo` wrappers to `QueueEntry` and `MobileQueueNode` frontend components, preserving their `displayName` properties for React DevTools.
🎯 **Why**: Both components are rendered inside a list/virtualized list (`QueueNodes` and `MobileQueueNodes`) and receive purely primitive props (`node_id`, `nodeId`, `index`). However, when global state changes in the parent, the lack of memoization causes an O(N) re-render of every single row in the list, increasing render times and hurting UI responsiveness on scroll or state changes.
📊 **Impact**: Significantly reduces re-renders by skipping execution for row items that haven't changed props, directly improving list scrolling smoothness and responsiveness by effectively turning O(N) re-renders into O(1).
🔬 **Measurement**: Verify via React DevTools Profiler that interacting with list items (like checking off an entry) does not re-render the surrounding siblings.

*(Additionally suppressed an unused auto-generated struct dead code warning in `api_v2/src/gen.rs` to satisfy strict `cargo clippy -D warnings` CI checks).*

---
*PR created automatically by Jules for task [2782571071996672748](https://jules.google.com/task/2782571071996672748) started by @kshramt*