### PR TITLE
⚡ Bolt: [performance improvement] Memoize QueueEntry and MobileQueueNode

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Memoize list row component to prevent O(N) re-renders during scrolling in react-virtuoso. */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Memoize list row component to prevent unnecessary re-renders in mapped arrays. */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What**: Wrapped `QueueEntry` (in `client/src/QueueEntry.tsx`) and `MobileQueueNode` (in `client/src/components.tsx`) with `React.memo` and added `displayName`s.
🎯 **Why**: Unmemoized list row components passed to virtualized lists (`react-virtuoso`) or mapped arrays re-render unnecessarily when their parent component updates, leading to O(N) re-renders during scrolling or state changes.
📊 **Impact**: Prevents O(N) re-renders for list elements. The impact is specifically noticeable when scrolling quickly through the virtualized `QueueEntry` lists or when the parent `MobileQueueNodes` updates, reducing CPU cycles and avoiding frame drops.
🔬 **Measurement**: Use the React DevTools Profiler. Record a session while scrolling the queue on mobile or desktop; observe that `QueueEntry` and `MobileQueueNode` no longer re-render when their primitive props (`node_id` and `index`) have not changed.

---
*PR created automatically by Jules for task [4055346142473656316](https://jules.google.com/task/4055346142473656316) started by @kshramt*