### PR TITLE
🛡️ Sentinel: [security improvement] Enforce strict HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - API Security Headers Enforcement
+**Vulnerability:** The Axum backend API lacked basic HTTP security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy), increasing the risk of content injection or clickjacking if API responses were somehow rendered in a browser context.
+**Learning:** Extracting the `axum::Router` configuration from `main` into a standalone function `pub fn app(state: Arc<AppState>) -> axum::Router` allows for clean, isolated testing of middleware (like security headers) using `tower::ServiceExt::oneshot` against non-existent routes without requiring a live database connection.
+**Prevention:** Ensure all new services or refactored router configurations apply strict default headers (e.g., `default-src 'none'`) and maintain testable isolation for their middleware stacks.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,46 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::if_not_present(
+                hyper::header::CONTENT_SECURITY_POLICY,
+                axum::http::HeaderValue::from_static(
+                    "default-src 'none'; frame-ancestors 'none'; sandbox",
+                ),
+            ),
+        )
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::if_not_present(
+                hyper::header::STRICT_TRANSPORT_SECURITY,
+                axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+            ),
+        )
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::if_not_present(
+                hyper::header::X_FRAME_OPTIONS,
+                axum::http::HeaderValue::from_static("DENY"),
+            ),
+        )
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::if_not_present(
+                hyper::header::X_CONTENT_TYPE_OPTIONS,
+                axum::http::HeaderValue::from_static("nosniff"),
+            ),
+        )
+        .layer(
+            tower_http::set_header::SetResponseHeaderLayer::if_not_present(
+                hyper::header::REFERRER_POLICY,
+                axum::http::HeaderValue::from_static("no-referrer"),
+            ),
+        )
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +425,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +435,67 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        // Initialize AppState with dummy values for testing middleware without DB
+        let dummy_pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .expect("Failed to create dummy pool");
+        let state = std::sync::Arc::new(AppState::new(0, dummy_pool));
+
+        let app = app(state);
+
+        // Send request to an unknown route to trigger 404 and headers middleware
+        let request = Request::builder()
+            .uri("/api/v2/not-found")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        // Verify headers are present and correctly set
+        assert_eq!(
+            response
+                .headers()
+                .get(hyper::header::CONTENT_SECURITY_POLICY)
+                .unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(hyper::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(hyper::header::X_FRAME_OPTIONS)
+                .unwrap(),
+            "DENY"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(hyper::header::X_CONTENT_TYPE_OPTIONS)
+                .unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(hyper::header::REFERRER_POLICY)
+                .unwrap(),
+            "no-referrer"
+        );
+    }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Axum API endpoints lacked standard HTTP security headers, failing to instruct potential web clients to disable untrusted loading sources, sniffing, or embedded rendering. While primarily a JSON API, if a browser were tricked into executing API responses or embedding them in a frame, it could lead to potential Cross-Site Scripting (XSS) via content sniffing or Clickjacking attacks.
🎯 Impact: Exploitation could theoretically trick browsers parsing raw API responses into executing unintended behaviors or leaking data via framing.
🔧 Fix: Extracted the Axum router configuration out of `main` into a testable public function (`pub fn app`) and added `tower_http::set_header::SetResponseHeaderLayer` middleware. Applied strict, standard headers (`default-src 'none'`) specifically suited for API communication that won't require HTML generation.
✅ Verification: An integration test `test_security_headers` using `tower::ServiceExt::oneshot` was added to verify the middleware appends all security headers locally without requiring a live database. Additionally, `cargo test` successfully executed in `api_v2`, and frontend test suites (`make check`) reported no API compatibility regressions.

---
*PR created automatically by Jules for task [16242815046863294243](https://jules.google.com/task/16242815046863294243) started by @kshramt*