### PR TITLE
🎨 Palette: [UX improvement] Add tooltips and ARIA labels to primary icon buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,8 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add child"
+      title="Add child"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Copy ID"
+      title="Copy ID"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
**💡 What:** Added explicit `aria-label` and `title` attributes to primary icon-only buttons (`StartButton`, `StartConcurrentButton`, `AddButton`, and `CopyNodeIdButton`).

**🎯 Why:** Icon-only buttons lack accessible names by default, making them completely opaque to screen reader users (who would just hear "button"). Additionally, desktop users benefit from native tooltips (`title`) to understand what the icons represent before clicking them.

**📸 Before/After:** Visual layout remains identical. Hovering over the buttons now displays a native tooltip. Screen readers now announce the buttons correctly (e.g., "Start, button").

**♿ Accessibility:** 
- Added accessible names for assistive technologies.
- Improved discoverability for sighted users via tooltips.

---
*PR created automatically by Jules for task [9909239153550518343](https://jules.google.com/task/9909239153550518343) started by @kshramt*