### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Testing Axum Middleware without Database
+**Learning:** Testing application-level middleware (like `tower_http::set_header`) in `axum` routing can be cleanly decoupled from database dependencies. By initializing a `PgPoolOptions` connection with `connect_lazy` and a dummy DSN (e.g., `postgres://invalid...`), tests can run purely against the routing layer using `tower::ServiceExt::oneshot`.
+**Action:** When adding HTTP headers or lightweight middleware in `axum`, always extract the router into a pure function taking injected state. Write explicit unit tests utilizing `connect_lazy` and `oneshot` against non-existent or dummy routes (e.g., `/not-found`) to verify middleware behavior locally without requiring a live Postgres instance.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,35 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+
+    app.layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::CONTENT_SECURITY_POLICY,
+        axum::http::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::STRICT_TRANSPORT_SECURITY,
+        axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::HeaderName::from_static("x-frame-options"),
+        axum::http::HeaderValue::from_static("DENY"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::HeaderName::from_static("x-content-type-options"),
+        axum::http::HeaderValue::from_static("nosniff"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::HeaderName::from_static("referrer-policy"),
+        axum::http::HeaderValue::from_static("no-referrer"),
+    ))
+    .layer(tower_http::trace::TraceLayer::new_for_http())
+    .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +414,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +424,46 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+        let state = Arc::new(AppState::new(0, pool));
+        let app = app(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v2/not-found")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get(hyper::header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers
+                .get(hyper::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(headers.get("x-content-type-options").unwrap(), "nosniff");
+        assert_eq!(headers.get("referrer-policy").unwrap(), "no-referrer");
+    }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard HTTP security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
🎯 Impact: Without these headers, the API could be vulnerable to clickjacking, MIME-type sniffing, or cross-site scripting (XSS) if serving user content directly or if framed maliciously.
🔧 Fix: Extracted the Axum router into an `app` function and added `tower_http::set_header` layers configuring standard secure defaults (e.g., `default-src 'none'`).
✅ Verification: An inline unit test using `connect_lazy` and `oneshot` verifies that responses contain the correct headers. Tests run successfully via `cargo test`.

---
*PR created automatically by Jules for task [3643177629819822493](https://jules.google.com/task/3643177629819822493) started by @kshramt*