### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+/client/dist/
+/client/dev-dist/
+/client/coverage/

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility on Icon-only Buttons
+**Learning:** React elements passed to `aria-label` or `title` will be stringified as `[object Object]`. They must be properly evaluated to strings. Also, when using Material UI icon span (`<span className="material-icons">...</span>`), the span must have `aria-hidden="true"` so screen readers do not announce the ligature text (e.g. "close"), but the parent button MUST have a descriptive `aria-label`.
+**Action:** Always test `aria-label` and `title` values when passed dynamically. Add `aria-hidden="true"` to Material UI icons inside buttons, and ensure the button has a valid string `aria-label`.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label={is_copied ? "Copied" : "Copy Node ID"}
+      title={is_copied ? "Copied" : "Copy Node ID"}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Undo"
+      title="Undo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move Up"
+      title="Move Up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +79,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move Down"
+      title="Move Down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -15,6 +15,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Evaluate"
+      title="Evaluate"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -75,6 +75,8 @@ const Details = (props: { node_id: types.TNodeId }) => {
         </select>
         <button
           className="btn-icon"
+          aria-label="Add Parents"
+          title="Add Parents"
           onClick={handle_add_parents}
           onDoubleClick={utils.prevent_propagation}
         >
@@ -82,6 +84,8 @@ const Details = (props: { node_id: types.TNodeId }) => {
         </button>
         <button
           className="btn-icon"
+          aria-label="Add Children"
+          title="Add Children"
           onClick={handle_add_children}
           onDoubleClick={utils.prevent_propagation}
         >
@@ -109,6 +113,8 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Show Details"
+      title="Show Details"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start Concurrently"
+      title="Start Concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      aria-label="Stop"
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as Done"
+      title="Mark as Done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as Don't"
+      title="Mark as Don't"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TogglePinButton/index.tsx
+++ b/client/src/TogglePinButton/index.tsx
@@ -16,6 +16,8 @@ const TogglePinButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label={is_pinned ? "Unpin" : "Pin"}
+      title={is_pinned ? "Unpin" : "Pin"}
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to Top"
+      title="Move to Top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -4,40 +4,128 @@ export const MINUTE = 60 * 1_000;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
 
-export const DELETE_MARK = <span className="material-icons">close</span>;
+export const DELETE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    close
+  </span>
+);
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
+export const START_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    play_arrow
+  </span>
+);
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons">double_arrow</span>
+  <span className="material-icons" aria-hidden="true">
+    double_arrow
+  </span>
 );
-export const ADD_MARK = <span className="material-icons">add</span>;
-export const DONE_MARK = <span className="material-icons">done</span>;
-export const DONT_MARK = <span className="material-icons">delete</span>;
-export const DETAIL_MARK = <span className="material-icons">more_vert</span>;
-export const COPY_MARK = <span className="material-icons">content_copy</span>;
-export const STOP_MARK = <span className="material-icons">stop</span>;
-export const TOP_MARK = <span className="material-icons">arrow_upward</span>;
-export const UNDO_MARK = <span className="material-icons">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons">south</span>;
-export const EVAL_MARK = <span className="material-icons">functions</span>;
-export const TOC_MARK = <span className="material-icons">toc</span>;
+export const ADD_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    add
+  </span>
+);
+export const DONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    done
+  </span>
+);
+export const DONT_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    delete
+  </span>
+);
+export const DETAIL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    more_vert
+  </span>
+);
+export const COPY_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_copy
+  </span>
+);
+export const STOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    stop
+  </span>
+);
+export const TOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_upward
+  </span>
+);
+export const UNDO_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    undo
+  </span>
+);
+export const MOVE_UP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    north
+  </span>
+);
+export const MOVE_DOWN_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    south
+  </span>
+);
+export const EVAL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    functions
+  </span>
+);
+export const TOC_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    toc
+  </span>
+);
 export const FORWARD_MARK = (
-  <span className="material-icons">arrow_forward_ios</span>
+  <span className="material-icons" aria-hidden="true">
+    arrow_forward_ios
+  </span>
 );
-export const BACK_MARK = <span className="material-icons">arrow_back_ios</span>;
-export const SEARCH_MARK = <span className="material-icons">search</span>;
-export const IDS_MARK = <span className="material-icons">content_paste</span>;
-export const MOBILE_MARK = <span className="material-icons">smartphone</span>;
+export const BACK_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_back_ios
+  </span>
+);
+export const SEARCH_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    search
+  </span>
+);
+export const IDS_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_paste
+  </span>
+);
+export const MOBILE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    smartphone
+  </span>
+);
 export const DESKTOP_MARK = (
-  <span className="material-icons">desktop_windows</span>
+  <span className="material-icons" aria-hidden="true">
+    desktop_windows
+  </span>
 );
-export const IS_FULL_MARK = <span className="material-icons">expand_more</span>;
-export const IS_NONE_MARK = <span className="material-icons">expand_less</span>;
+export const IS_FULL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_more
+  </span>
+);
+export const IS_NONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_less
+  </span>
+);
 export const IS_PARTIAL_MARK = (
-  <span className="material-icons">chevron_right</span>
+  <span className="material-icons" aria-hidden="true">
+    chevron_right
+  </span>
 );
 
 export const SPINNER = (


### PR DESCRIPTION
## 💡 What
Added explicit `aria-label` and `title` tags to multiple icon-only utility buttons (`AddButton`, `StopButton`, `TopButton`, etc.) throughout `client/src`. Also appended `aria-hidden="true"` to Material UI icon spans so screen readers do not announce the ligature text alongside the labels.

## 🎯 Why
Screen readers will announce buttons with just icon spans using the ligature text (e.g. "close"), which is often confusing. Sighted users also lacked tooltips for many of these small icon-only buttons, reducing overall clarity. The added ARIA labels and tooltips make the UI explicitly navigable and descriptive.

## 📸 Before/After
Before: Hovering over action buttons showed nothing, screen readers announced "Play Arrow".
After: Hovering over buttons presents native tooltips explaining their actions, and screen readers read correctly assigned semantic roles and labels.

## ♿ Accessibility
- Fixed icon-only interactive elements lacking native descriptive text
- Added `aria-hidden` to avoid duplicate and unhelpful readouts of ligature text.

---
*PR created automatically by Jules for task [14471333363527951738](https://jules.google.com/task/14471333363527951738) started by @kshramt*