### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-24 - Accessibility for Icon-only Buttons
+**Learning:** React Material UI icon spans (e.g., `<span className="material-icons">`) without surrounding text lack semantic meaning. If placed inside an icon-only button without an `aria-label`, the button becomes completely inaccessible to screen readers.
+**Action:** When creating or modifying icon-only buttons (`btn-icon`), always verify that the parent `<button>` has both an `aria-label` and `title` to provide an accessible name and a helpful hover tooltip.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,8 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add child"
+      title="Add child"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Copy ID"
+      title="Copy ID"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Undo (to todo)"
+      title="Undo (to todo)"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -15,6 +15,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Evaluate"
+      title="Evaluate"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -109,6 +109,8 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Show details"
+      title="Show details"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -20,6 +20,7 @@ const StopButton = ({
     <button
       className="btn-icon"
       aria-label="Stop."
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
+      title="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as won't do"
+      title="Mark as won't do"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to top"
+      title="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to numerous icon-only `<button className="btn-icon">` components across the codebase.
🎯 **Why:** To make these UI elements readable to screen readers and to provide native browser tooltips on hover, improving usability for both keyboard/mouse and assistive tech users.
📸 **Before/After:** Before, screen readers would either announce nothing or misread the ligature text for buttons like `<span className="material-icons">play_arrow</span>`. After, they correctly announce the action (e.g., "Start"). Native tooltips are now shown on hover.
♿ **Accessibility:** Fixes severe accessibility barriers where icon-only buttons lacked an accessible name. Documented the crucial learning in `.jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [260893483557392226](https://jules.google.com/task/260893483557392226) started by @kshramt*