### PR TITLE
⚡ Bolt: [performance improvement] Wrap QueueEntry in React.memo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-24 - Prevent O(N) re-renders in virtualized lists
+**Learning:** Virtualized lists using `react-virtuoso` will still trigger re-renders on every scroll tick or state change if list item components receiving primitive props are not memoized.
+**Action:** Always wrap list item components (e.g., `QueueEntry`, `MobileQueueNode`) receiving primitive props in `React.memo` to prevent unnecessary O(N) DOM reconciliations during fast scrolling and global state updates. Be sure to append `.displayName` for DevTools visibility.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+/** ⚡ Bolt: Prevent O(N) re-renders for list items during scrolling and state updates */
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+/** ⚡ Bolt: Prevent O(N) re-renders for list items during scrolling and state updates */
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` and `MobileQueueNode` components with `React.memo()`.
🎯 Why: Virtualized lists using `react-virtuoso` will still trigger unnecessary component reconciliation re-renders on scroll ticks or store updates if item components receiving primitive properties are not memoized.
📊 Impact: Prevents O(N) re-renders of the task queue elements on state updates, significantly improving responsiveness and framerates during fast scrolling or typing.
🔬 Measurement: Use React Profiler. Record scrolling down the queue. The timeline will show these components grayed out (bypassing render phase) when their specific `nodeId` and `index` props have not changed.

---
*PR created automatically by Jules for task [8074924154184781685](https://jules.google.com/task/8074924154184781685) started by @kshramt*