### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Security Headers Middleware]
+**Vulnerability:** Missing strict security headers in Axum API.
+**Learning:** By extracting the application setup logic into a `pub fn app(state: Arc<AppState>) -> axum::Router` function, we can cleanly wrap it with a `SetResponseHeaderLayer` to add comprehensive headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy). To test this logic without a running DB, we can use `PgPoolOptions::new().connect_lazy("postgres://invalid:invalid@localhost/invalid")` with `tower::ServiceExt`'s `oneshot`.
+**Prevention:** Always verify that security middlewares are tested using `oneshot` requests in unit tests rather than relying entirely on end-to-end integration environments.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,35 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+
+    app.layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::CONTENT_SECURITY_POLICY,
+        axum::http::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::STRICT_TRANSPORT_SECURITY,
+        axum::http::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::X_FRAME_OPTIONS,
+        axum::http::HeaderValue::from_static("DENY"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::X_CONTENT_TYPE_OPTIONS,
+        axum::http::HeaderValue::from_static("nosniff"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        axum::http::header::HeaderName::from_static("referrer-policy"),
+        axum::http::HeaderValue::from_static("strict-origin-when-cross-origin"),
+    ))
+    .layer(tower_http::trace::TraceLayer::new_for_http())
+    .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +414,8 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +425,46 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+        let state = Arc::new(AppState::new(0, pool));
+        let router = app(state);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/sys/health")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+        assert_eq!(
+            headers.get("content-security-policy").unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers.get("strict-transport-security").unwrap(),
+            "max-age=63072000; includeSubDomains; preload"
+        );
+        assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(headers.get("x-content-type-options").unwrap(), "nosniff");
+        assert_eq!(
+            headers.get("referrer-policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+    }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers on the API responses.
🎯 Impact: Lack of defense-in-depth headers could leave users susceptible to clickjacking, MIME-sniffing, or cross-site scripting risks if HTML were eventually served or if clients didn't restrict framing.
🔧 Fix: Extracted app logic and added `tower-http` `SetResponseHeaderLayer` to add standard strict security headers.
✅ Verification: `cargo test` in `api_v2` executes the new integration test covering the presence of all five security headers.

---
*PR created automatically by Jules for task [13779943451563615589](https://jules.google.com/task/13779943451563615589) started by @kshramt*