### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-27 - Added ARIA labels to button components
+**Learning:** Icon-only buttons using `<span className="material-icons">` across the app are missing `aria-label` and `title` attributes. They also missing `aria-hidden="true"` on the icon itself to prevent screen readers from reading the ligature text.
+**Action:** Adding these attributes to the core button components.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -27,6 +27,8 @@ export const AddButton = (props: {
   }, [props.node_id, dispatch, show_mobile, prefix]);
   return (
     <button
+      aria-label="Add"
+      title="Add"
       className="btn-icon"
       id={props.id}
       onClick={handle_click}

--- a/client/src/Calendar/AddButton.tsx
+++ b/client/src/Calendar/AddButton.tsx
@@ -19,7 +19,12 @@ const AddButton = (props: { timeId: string }) => {
     );
   }, [dispatch, props.timeId, nodeIds]);
   return (
-    <button className="btn-icon" onClick={handleClick}>
+    <button
+      aria-label="Add event"
+      title="Add event"
+      className="btn-icon"
+      onClick={handleClick}
+    >
       {consts.ADD_MARK}
     </button>
   );

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -22,6 +22,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   );
   return (
     <button
+      aria-label="Copy ID"
+      title="Copy ID"
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -13,6 +13,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Mark as todo"
+      title="Mark as todo"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -57,6 +57,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move up"
+      title="Move up"
       className="btn-icon"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
@@ -76,6 +78,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move down"
+      title="Move down"
       className="btn-icon"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -14,6 +14,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Evaluate"
+      title="Evaluate"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -108,6 +108,8 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   }, [dispatch, props.node_id]);
   return (
     <button
+      aria-label="Show details"
+      title="Show details"
       className="btn-icon"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -14,6 +14,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start"
+      title="Start"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -14,6 +14,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start concurrently"
+      title="Start concurrently"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -18,8 +18,9 @@ const StopButton = ({
 
   return (
     <button
+      aria-label="Stop"
+      title="Stop"
       className="btn-icon"
-      aria-label="Stop."
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -15,6 +15,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Mark as done"
+      title="Mark as done"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -15,6 +15,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Mark as don't"
+      title="Mark as don't"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TogglePinButton/index.tsx
+++ b/client/src/TogglePinButton/index.tsx
@@ -15,6 +15,8 @@ const TogglePinButton = (props: { node_id: types.TNodeId }) => {
   const is_pinned = pinned_sub_trees.includes(props.node_id);
   return (
     <button
+      aria-label="Toggle pin"
+      title="Toggle pin"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -12,6 +12,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Move to top"
+      title="Move to top"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -578,7 +578,12 @@ const Timeline = () => {
   return (
     <>
       {decade_nodes}
-      <button className="btn-icon" onClick={increment_count}>
+      <button
+        aria-label="Increment count"
+        title="Increment count"
+        className="btn-icon"
+        onClick={increment_count}
+      >
         {consts.ADD_MARK}
       </button>
     </>
@@ -785,13 +790,23 @@ const TimeNodeEntry = (props: { time_node_id: types.TTimeNodeId }) => {
       />
       {isOn && (
         <div className="flex w-fit gap-x-[0.125em]">
-          <button className="btn-icon" onClick={assign_nodes}>
+          <button
+            aria-label="Assign node"
+            title="Assign node"
+            className="btn-icon"
+            onClick={assign_nodes}
+          >
             {consts.ADD_MARK}
           </button>
           <CopyDescendantTimeNodesPlannedNodeIdsButton
             time_node_id={props.time_node_id}
           />
-          <button className="btn-icon" onClick={toggle_show_children}>
+          <button
+            aria-label="Toggle children"
+            title="Toggle children"
+            className="btn-icon"
+            onClick={toggle_show_children}
+          >
             {time_node === undefined || time_node.show_children === "partial"
               ? consts.IS_PARTIAL_MARK
               : time_node.show_children === "full"
@@ -863,7 +878,12 @@ const PlannedNode = (props: {
             </>
           )}
           <CopyNodeIdButton node_id={props.node_id} />
-          <button className="btn-icon" onClick={unassign_node}>
+          <button
+            aria-label="Unassign node"
+            title="Unassign node"
+            className="btn-icon"
+            onClick={unassign_node}
+          >
             {consts.DELETE_MARK}
           </button>
         </div>

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -4,40 +4,128 @@ export const MINUTE = 60 * 1_000;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
 
-export const DELETE_MARK = <span className="material-icons">close</span>;
+export const DELETE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    close
+  </span>
+);
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
+export const START_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    play_arrow
+  </span>
+);
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons">double_arrow</span>
+  <span className="material-icons" aria-hidden="true">
+    double_arrow
+  </span>
 );
-export const ADD_MARK = <span className="material-icons">add</span>;
-export const DONE_MARK = <span className="material-icons">done</span>;
-export const DONT_MARK = <span className="material-icons">delete</span>;
-export const DETAIL_MARK = <span className="material-icons">more_vert</span>;
-export const COPY_MARK = <span className="material-icons">content_copy</span>;
-export const STOP_MARK = <span className="material-icons">stop</span>;
-export const TOP_MARK = <span className="material-icons">arrow_upward</span>;
-export const UNDO_MARK = <span className="material-icons">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons">south</span>;
-export const EVAL_MARK = <span className="material-icons">functions</span>;
-export const TOC_MARK = <span className="material-icons">toc</span>;
+export const ADD_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    add
+  </span>
+);
+export const DONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    done
+  </span>
+);
+export const DONT_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    delete
+  </span>
+);
+export const DETAIL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    more_vert
+  </span>
+);
+export const COPY_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_copy
+  </span>
+);
+export const STOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    stop
+  </span>
+);
+export const TOP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_upward
+  </span>
+);
+export const UNDO_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    undo
+  </span>
+);
+export const MOVE_UP_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    north
+  </span>
+);
+export const MOVE_DOWN_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    south
+  </span>
+);
+export const EVAL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    functions
+  </span>
+);
+export const TOC_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    toc
+  </span>
+);
 export const FORWARD_MARK = (
-  <span className="material-icons">arrow_forward_ios</span>
+  <span className="material-icons" aria-hidden="true">
+    arrow_forward_ios
+  </span>
 );
-export const BACK_MARK = <span className="material-icons">arrow_back_ios</span>;
-export const SEARCH_MARK = <span className="material-icons">search</span>;
-export const IDS_MARK = <span className="material-icons">content_paste</span>;
-export const MOBILE_MARK = <span className="material-icons">smartphone</span>;
+export const BACK_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    arrow_back_ios
+  </span>
+);
+export const SEARCH_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    search
+  </span>
+);
+export const IDS_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    content_paste
+  </span>
+);
+export const MOBILE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    smartphone
+  </span>
+);
 export const DESKTOP_MARK = (
-  <span className="material-icons">desktop_windows</span>
+  <span className="material-icons" aria-hidden="true">
+    desktop_windows
+  </span>
 );
-export const IS_FULL_MARK = <span className="material-icons">expand_more</span>;
-export const IS_NONE_MARK = <span className="material-icons">expand_less</span>;
+export const IS_FULL_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_more
+  </span>
+);
+export const IS_NONE_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    expand_less
+  </span>
+);
 export const IS_PARTIAL_MARK = (
-  <span className="material-icons">chevron_right</span>
+  <span className="material-icons" aria-hidden="true">
+    chevron_right
+  </span>
 );
 
 export const SPINNER = (


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to icon-only buttons across the application (e.g., Add, Start, Stop, Delete). Added `aria-hidden="true"` to the underlying Material Icon spans to prevent screen readers from reading the ligature text.

🎯 Why: Icon-only buttons lacking accessible names are invisible or confusing to screen reader users. The ligature text (like "play_arrow") provides no meaningful context. This change makes all core interactions accessible via keyboard and screen readers, and adds helpful tooltips for mouse users.

📸 Before/After: Visual appearance is unchanged, but tooltips now appear on hover.

♿ Accessibility:
- Screen readers will now announce "Start" instead of "play arrow" or nothing.
- Fixed `aria-hidden` on Material Icons in `consts.tsx`.
- Ensured `aria-label` matches `title` on all core button components.

---
*PR created automatically by Jules for task [10592683896317808299](https://jules.google.com/task/10592683896317808299) started by @kshramt*