### PR TITLE
⚡ Bolt: [performance improvement] Add React.memo to prevent O(N) list item re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-28 - React.memo for Virtualized List Items
+**Learning:** List item components mapped with primitives (e.g. `node_id` and `index`) inside a virtualized list wrapper (`react-virtuoso` or map arrays) cause O(N) re-renders during scrolling and state updates if not memoized, but `React.memo` effectively resolves this without interfering with Jotai/Redux local subscriptions inside the components.
+**Action:** Identify mapping functions of list item children receiving scalar IDs and add `React.memo`, being careful to append `displayName` to maintain React DevTools readability.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    // ⚡ Bolt: Using React.memo to prevent O(N) re-renders for unchanged list items
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
+  // ⚡ Bolt: Using React.memo to prevent O(N) re-renders for unchanged list items
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What**: Wrapped `QueueEntry` and `MobileQueueNode` list item components with `React.memo` and assigned standard `displayName`.
🎯 **Why**: When virtualized lists scroll or parents undergo minor state updates, mapping functions re-render all children. By using `React.memo`, we prevent unnecessary O(N) re-renders for unchanged list items that only rely on primitives (like `node_id` and `index`), saving compute resources since Jotai/Redux handles internal state directly. 
📊 **Impact**: Reduces component unmount/re-mount and prop-check cycles significantly for long queue lists during scrolling and parent evaluation.
🔬 **Measurement**: Profiling the React Tree while scrolling the list will show far fewer re-rendered nodes (gray dots) compared to before where entire slices re-rendered.

---
*PR created automatically by Jules for task [16773583229611491941](https://jules.google.com/task/16773583229611491941) started by @kshramt*