### PR TITLE
🛡️ Sentinel: [security improvement] Add strict HTTP security headers to API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+**/dist/
+**/dev-dist/

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-05-24 - Strict Security Headers Configuration
+
+**Vulnerability:** The Axum backend API endpoints lacked standard HTTP security headers (e.g., CSP, HSTS, X-Frame-Options), leaving API clients unnecessarily exposed to certain classes of attacks (like MIME-sniffing or framing).
+**Learning:** In the `tower_http` crate within the Rust backend, applying multiple security headers to the `axum::Router` requires carefully chaining the `.overriding()` method calls on `SetResponseHeaderLayer` alongside the exact header constants from `hyper::header`. Furthermore, tests that instantiate the router must use a mocked database connection string via `connect_lazy()` so that CI tests don't immediately fail when attempting to connect to a nonexistent database.
+**Prevention:** Apply security headers centrally to the top-level app router during bootstrapping. Always ensure the `tower::ServiceExt::oneshot` method is used in conjunction with a `connect_lazy()` database pool to accurately mock HTTP tests without heavy infrastructure requirements.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,37 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=63072000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +416,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +426,45 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt; // for `oneshot` and `ready`
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let state = std::sync::Arc::new(AppState::new(
+            0,
+            sqlx::postgres::PgPoolOptions::new()
+                .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+                .unwrap(),
+        ));
+        let app = app(state);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get("content-security-policy").unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            response.headers().get("strict-transport-security").unwrap(),
+            "max-age=63072000; includeSubDomains"
+        );
+        assert_eq!(response.headers().get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(
+            response.headers().get("x-content-type-options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            response.headers().get("referrer-policy").unwrap(),
+            "no-referrer"
+        );
+    }
 }


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** The `api_v2` Axum backend endpoints were missing standard HTTP security headers (such as Content-Security-Policy, Strict-Transport-Security, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy).
**🎯 Impact:** While the risk to a JSON-only API is reduced compared to an HTML frontend, missing headers still increase the risk of MIME-type sniffing, clickjacking (if framed incorrectly), and potentially failing strict browser security baseline checks.
**🔧 Fix:** Applied `tower_http::set_header::SetResponseHeaderLayer` globally to the `axum::Router` to override and strictly enforce safe header values. Extracting the `app` initialization logic allowed for creating a lightweight inline integration test.
**✅ Verification:** A unit test was implemented in `api_v2/src/main.rs` that leverages `tower::ServiceExt::oneshot` to intercept an HTTP response from the router and assert the successful injection of all 5 security headers. Run `cargo test` inside `api_v2` to verify.

---
*PR created automatically by Jules for task [16917990310574754522](https://jules.google.com/task/16917990310574754522) started by @kshramt*