### PR TITLE
🛡️ Sentinel: [security improvement] Add strict security headers to api_v2

### DIFF
--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -34,6 +34,7 @@ pub struct FakeIdpCreateUserResponse {
     pub id_token: IdToken,
 }
 #[rustfmt::skip]
+#[allow(dead_code)]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,36 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: std::sync::Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::REFERRER_POLICY,
+            axum::http::HeaderValue::from_static("no-referrer"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +415,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +425,49 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+        let state = std::sync::Arc::new(AppState::new(0, pool));
+        let router = app(state);
+
+        let request = Request::builder()
+            .uri("/")
+            .method("GET")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get(hyper::header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers
+                .get(hyper::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(headers.get(hyper::header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            headers.get(hyper::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            headers.get(hyper::header::REFERRER_POLICY).unwrap(),
+            "no-referrer"
+        );
+    }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The API v2 service did not explicitly configure security headers (such as `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`), leaving it potentially more vulnerable to clickjacking, MIME-type sniffing, and certain injection attacks depending on how endpoints are consumed.
🎯 Impact: Attackers could potentially exploit missing headers if endpoints serve HTML or context that allows execution, or frame the site, or trick the browser into sniffing MIME types.
🔧 Fix: Extracted the axum router into a standalone `app` function and chained `tower_http::set_header::SetResponseHeaderLayer` to inject strict security headers for all endpoints. Also added a `oneshot` test to verify the headers.
✅ Verification: Ran `cd api_v2 && cargo check && cargo test`, which executes the new unit test asserting the presence and strict values of the headers.

---
*PR created automatically by Jules for task [14538362888845517402](https://jules.google.com/task/14538362888845517402) started by @kshramt*