### PR TITLE
⚡ Bolt: [performance improvement] Prevent O(N) re-renders in EdgeList using shallowEqual

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-29 - Prevent O(N) React Redux Re-renders in Global Lists
+**Learning:** In list components reading nested maps from Redux global state (like `swapped_nodes.status`), directly selecting the top-level parent map (`useSelector(state => state.swapped_nodes.status)`) causes the list to unnecessarily re-render anytime *any* item's status updates, creating a severe O(N) re-render cascade.
+**Action:** Always derive the exact subset of required state for a component's specific children and memoize it inside `useSelector` using `shallowEqual` (from `react-redux`) rather than relying on top-level state object identities.

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1029,16 +1029,27 @@ const EdgeList = (props: {
   const children = utils.assertV(
     useSelector((state) => state.swapped_nodes.children?.[props.node_id]),
   );
-  const statuses = utils.assertV(
-    useSelector((state) => state.swapped_nodes.status),
+  const edge_ids = React.useMemo(
+    () => ops.sorted_keys_of(children),
+    [children],
   );
-  const cs = utils.assertV(useSelector((state) => state.swapped_edges.c ?? {}));
+  const childStatuses = useSelector((state) => {
+    const all_cs = state.swapped_edges.c ?? {};
+    const all_statuses = state.swapped_nodes.status ?? {};
+    const res: Record<string, string> = {};
+    for (const edgeId of edge_ids) {
+      const c = all_cs[edgeId];
+      if (c && all_statuses[c]) {
+        res[edgeId] = all_statuses[c];
+      }
+    }
+    return res;
+  }, Rr.shallowEqual);
   const todos = Array<JSX.Element>();
   const dones = Array<JSX.Element>();
   const donts = Array<JSX.Element>();
-  for (const edgeId of ops.sorted_keys_of(children)) {
-    const c = cs[edgeId];
-    const status = statuses[c];
+  for (const edgeId of edge_ids) {
+    const status = childStatuses[edgeId];
     if (status === "todo") {
       todos.push(<Edge edge_id={edgeId} key={edgeId} prefix={props.prefix} />);
     } else if (status === "done") {
@@ -1047,7 +1058,6 @@ const EdgeList = (props: {
       donts.push(<Edge edge_id={edgeId} key={edgeId} prefix={props.prefix} />);
     }
   }
-  const edge_ids = ops.sorted_keys_of(children);
   return edge_ids.length ? (
     <ol className="list-outside pl-[4em] content-visibility-auto">
       {todos.concat(dones, donts)}


### PR DESCRIPTION
💡 **What**: Refactored the `useSelector` logic in the `EdgeList` component in `client/src/components.tsx` to derive and select only the child statuses pertinent to its specific children, and memoized this subset using `react-redux`'s `shallowEqual`. 

🎯 **Why**: Previously, `EdgeList` accessed the entire `swapped_nodes.status` map globally. This meant any single node status update anywhere in the application would trigger a re-render for every single `EdgeList` component in the DOM, creating a severe O(N) performance bottleneck.

📊 **Impact**: Reduces unnecessary re-renders in global tree lists by mapping exactly to child edge changes, significantly improving UI responsiveness when rendering large trees or queues.

🔬 **Measurement**: Observe rendering cycles in React DevTools Profiler while updating a task status. `EdgeList` components for unrelated subtrees should no longer re-render.

---
*PR created automatically by Jules for task [77392174282774118](https://jules.google.com/task/77392174282774118) started by @kshramt*