### PR TITLE
⚡ Bolt: Memoize QueueEntry and MobileQueueNode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ yarn-error.log*
 
 **/target/
 **/ignored/
+**/dist/
+**/dev-dist/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-30 - Prevented Unnecessary Re-Renders in List Components
+**Learning:** Virtualized lists like `react-virtuoso` handle heavy rendering, but list item components receiving primitive props (like `node_id` and `index`) can still suffer from O(N) global re-renders during state updates if not properly memoized.
+**Action:** When implementing list item components that accept primitive props (e.g., `QueueEntry`, `MobileQueueNode`), always wrap them in `React.memo` to skip unnecessary parent-driven re-renders, and append `displayName` for DevTools readability.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,18 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,7 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +29,8 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,7 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1235,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` and `MobileQueueNode` in `React.memo` and assigned their `displayName`.
🎯 Why: Both components receive primitive props (`node_id`, `index`) and render as list items in queue lists (using Virtuoso). Without memoization, they re-render when the parent virtualized list or other global state updates, causing unnecessary O(N) rendering.
📊 Impact: Skips unnecessary parent-driven re-renders of all visible list items during scrolling and unrelated state updates, significantly reducing CPU load and improving list interactivity.
🔬 Measurement: Verify rendering skipped in React DevTools Profiler by inspecting "QueueEntry" and "MobileQueueNode" components during state updates.

---
*PR created automatically by Jules for task [11022106810871689621](https://jules.google.com/task/11022106810871689621) started by @kshramt*