### PR TITLE
🛡️ Sentinel: [security improvement] Add strict HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-05-01 - Added Security Headers Middleware
+
+**Vulnerability:** The application was missing basic standard security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy), increasing the risk of Clickjacking, MIME-sniffing, and Cross-Site Scripting (XSS).
+**Learning:** Adding HTTP security headers natively via Axum/Tower requires extracting the router out of the `main` execution scope into an `app` module to enable component testing without hitting the database, allowing middleware checks through `oneshot` simulated requests.
+**Prevention:** Always encapsulate Axum routing layer initialization in a testable library module block (`app(state)`) rather than intertwining it with process initialization in `main.rs`, and enforce strict security header assertions as part of integration tests.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -34,6 +34,7 @@ pub struct FakeIdpCreateUserResponse {
     pub id_token: IdToken,
 }
 #[rustfmt::skip]
+#[allow(dead_code)]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -349,6 +349,36 @@ impl AppState {
             pool,
         }
     }
+}
+
+pub fn app(state: std::sync::Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    app.with_state(state)
+        .layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::REFERRER_POLICY,
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ))
 }
 
 fn parse_u16(s: String) -> Option<u16> {
@@ -385,12 +415,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +425,50 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let state = std::sync::Arc::new(AppState {
+            id_generator: std::sync::Mutex::new(id_generator::SortableIdGenerator::new(0)),
+            pool: sqlx::postgres::PgPoolOptions::new()
+                .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+                .unwrap(),
+        });
+
+        let router = app(state);
+
+        let request = Request::builder()
+            .uri("/")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let response = router.oneshot(request).await.unwrap();
+
+        let headers = response.headers();
+        assert_eq!(
+            headers.get(hyper::header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers
+                .get(hyper::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(headers.get(hyper::header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            headers.get(hyper::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            headers.get(hyper::header::REFERRER_POLICY).unwrap(),
+            "no-referrer"
+        );
+    }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) leaves the application susceptible to basic attacks like Clickjacking, MIME-sniffing, and certain types of XSS.
🎯 Impact: Attackers could potentially frame the API to trick users, sniff contents to bypass content restrictions, or downgrade connections from HTTPS.
🔧 Fix: Extracted the Axum router into a standalone `app` function and applied `tower_http::set_header::SetResponseHeaderLayer` to uniformly set strict security headers (`default-src 'none'`, `DENY`, `nosniff`, `max-age=31536000`, `no-referrer`).
✅ Verification: Ran `cargo check`, `cargo test`, `cargo fmt`, `cargo clippy`, and frontend `make check`. A new inline unit test explicitly verifies these headers exist on responses using `oneshot` requests.

---
*PR created automatically by Jules for task [2085462554632834426](https://jules.google.com/task/2085462554632834426) started by @kshramt*