### PR TITLE
⚡ Bolt: [performance improvement] Memoize QueueEntry and MobileQueueNode

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - React.memo on List Components
+**Learning:** Virtualized lists and long map iterations in React can suffer severe performance degradation if the child components aren't memoized and rely on global/frequent prop updates. Primitive props like node_id and index make components perfect candidates for React.memo.
+**Action:** Always wrap components rendered inside loops or virtualized lists (like `react-virtuoso`) in `React.memo` when they receive primitive props to prevent O(N) re-renders, and remember to append `.displayName` to preserve React DevTools readability.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: Wrapped QueueEntry in React.memo to prevent O(N) re-renders during virtualized list scrolling and updates
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+// ⚡ Bolt: Wrapped MobileQueueNode in React.memo to prevent O(N) re-renders when parent states change, improving mobile queue scrolling performance
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` and `MobileQueueNode` in `React.memo` and added `displayName`s.
🎯 Why: In virtualized lists (like those using `react-virtuoso`) or large mapped lists, passing primitive props (`node_id`, `index`) without memoizing the list components causes unnecessary O(N) re-renders across the entire visible set of children whenever the parent re-renders due to global state changes.
📊 Impact: Expected to significantly reduce JS main thread blocking and React reconciliation time during scroll and queue modifications, reducing re-renders of unaffected nodes to near zero.
🔬 Measurement: Verify with React DevTools Profiler by toggling "Record why each component rendered while profiling" and interacting with the Queue list. Unaffected nodes should no longer show as re-rendered.

---
*PR created automatically by Jules for task [12545926881643626794](https://jules.google.com/task/12545926881643626794) started by @kshramt*