### PR TITLE
🛡️ Sentinel: Add strict security headers to Axum router

### DIFF
--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -33,6 +33,7 @@ pub struct FakeIdpCreateUserRequest {
 pub struct FakeIdpCreateUserResponse {
     pub id_token: IdToken,
 }
+#[allow(dead_code)]
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct FakeIdpCreateIdTokenRequest {

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,36 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: std::sync::Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::CONTENT_SECURITY_POLICY,
+        hyper::header::HeaderValue::from_static(
+            "default-src 'none'; frame-ancestors 'none'; sandbox",
+        ),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::STRICT_TRANSPORT_SECURITY,
+        hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::HeaderName::from_static("x-frame-options"),
+        hyper::header::HeaderValue::from_static("DENY"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::HeaderName::from_static("x-content-type-options"),
+        hyper::header::HeaderValue::from_static("nosniff"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::HeaderName::from_static("referrer-policy"),
+        hyper::header::HeaderValue::from_static("no-referrer"),
+    ))
+    .layer(tower_http::trace::TraceLayer::new_for_http())
+    .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +415,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +425,48 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        // Initialize dummy AppState with a lazy connection string for tests
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+        let state = std::sync::Arc::new(AppState::new(0, pool));
+
+        let app = app(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get(hyper::header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers
+                .get(hyper::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(headers.get("x-content-type-options").unwrap(), "nosniff");
+        assert_eq!(headers.get("referrer-policy").unwrap(), "no-referrer");
+    }
 }


### PR DESCRIPTION
**Severity**: MEDIUM
**Vulnerability**: The API endpoints were missing fundamental HTTP security headers, leaving them potentially vulnerable to common web attacks like clickjacking, MIME-sniffing, and downgrade attacks, although the risk is partially mitigated since it strictly serves JSON.
**Impact**: Lack of these headers can lead to browser-side vulnerabilities. For instance, without X-Frame-Options, an attacker might embed the API responses in an iframe for clickjacking or data extraction.
**Fix**: Added strict security headers (`Content-Security-Policy: default-src 'none'`, `Strict-Transport-Security`, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: no-referrer`) to the Axum router using `tower-http`. Refactored the main entrypoint to extract an `app()` function, which enabled creating integration tests for the router middleware to assure the headers are always appended.
**Verification**: Run `cargo test` in the `api_v2` directory to run the newly added middleware integration test `test_security_headers`.

---
*PR created automatically by Jules for task [13267638573908534982](https://jules.google.com/task/13267638573908534982) started by @kshramt*