### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Missing Security Headers in Backend Service API
+**Vulnerability:** The API served by `api_v2/src/main.rs` via Axum did not include basic security headers like `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`. Although it's purely a JSON API, defense-in-depth via headers is a foundational security best practice.
+**Learning:** Axum routes built via generated endpoints do not automatically gain security headers without explicitly layering them via `tower_http`. A pure backend API can use strict `default-src 'none'` for CSP to fully lock down resource loading, as no browser navigation or HTML rendering is performed.
+**Prevention:** Always wrap base Axum applications with standard security layers like `tower_http::set_header::SetResponseHeaderLayer` using security header constants provided by `hyper::header`. This ensures standard protections are injected into all HTTP responses.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,36 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: std::sync::Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::REFERRER_POLICY,
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +415,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +425,61 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+        let state = std::sync::Arc::new(AppState::new(0, pool));
+        let app = app(state);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response
+                .headers()
+                .get(hyper::header::CONTENT_SECURITY_POLICY)
+                .unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(hyper::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=63072000; includeSubDomains; preload"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(hyper::header::X_FRAME_OPTIONS)
+                .unwrap(),
+            "DENY"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(hyper::header::X_CONTENT_TYPE_OPTIONS)
+                .unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(hyper::header::REFERRER_POLICY)
+                .unwrap(),
+            "no-referrer"
+        );
+    }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The API served by `api_v2/src/main.rs` via Axum did not include basic security headers like `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`.
🎯 Impact: Although the API is purely JSON based, defense-in-depth is a foundational security best practice. Without these headers, applications consuming the API or unexpected rendering contexts could be exposed to sniffing, framing, or other standard web vulnerabilities if the endpoints are misused.
🔧 Fix: Wrapped the base Axum application with standard security layers using `tower_http::set_header::SetResponseHeaderLayer` and `hyper::header` constants. Applied a strict `default-src 'none'` CSP since no resources should be loaded via this API.
✅ Verification: An integration test `test_security_headers` was added in `api_v2/src/main.rs` using `tower::ServiceExt`'s `oneshot` method to simulate an HTTP request and assert response headers without requiring a live server or database.

---
*PR created automatically by Jules for task [9485326536738213681](https://jules.google.com/task/9485326536738213681) started by @kshramt*