### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move up"
+      title="Move up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +79,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move down"
+      title="Move down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to several icon-only buttons across the application (AddButton, MoveUpButton, MoveDownButton, StartButton, StartConcurrentButton).

🎯 **Why:** Icon-only buttons without accessible names are invisible to screen readers and lack context for keyboard/sighted users on hover. This change ensures the buttons are properly announced and have native tooltips.

📸 **Before/After:** No visual changes to the UI layout, only tooltips appear on hover.

♿ **Accessibility:**
- Screen readers will now announce "Add", "Start", "Start concurrently", "Move up", and "Move down" instead of unlabelled buttons.
- Sighted users receive hover tooltips.

---
*PR created automatically by Jules for task [13053307878487972114](https://jules.google.com/task/13053307878487972114) started by @kshramt*