### PR TITLE
⚡ Bolt: [performance improvement] React.memo in Virtualized Lists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - Virtualized List Optimization
+**Learning:** Wrapping children components of virtualized lists (like `react-virtuoso`) with `React.memo` is critical to prevent O(N) re-renders during scrolling and interactions. Virtuoso manages the subset of visible nodes, but React may needlessly re-render the individual nodes without memoization.
+**Action:** Always wrap components rendered inside a virtualized list, like `QueueEntry` or `MobileQueueNode`, in `React.memo()`. Also, remember to set `displayName` for easier React DevTools debugging.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -34,6 +34,7 @@ pub struct FakeIdpCreateUserResponse {
     pub id_token: IdToken,
 }
 #[rustfmt::skip]
+#[allow(dead_code)]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,21 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: Wrap in React.memo to prevent unnecessary O(N) re-renders during scrolling in react-virtuoso virtualized lists
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+// ⚡ Bolt: Wrap in React.memo to prevent unnecessary O(N) re-renders for mapped arrays
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1236,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` and `MobileQueueNode` children components inside virtualized/mapped lists in `React.memo()`. Fixed clippy warning.
🎯 Why: `react-virtuoso` and native array maps can aggressively re-render their children during fast scrolling or generic state updates. Since these components receive simple primitive props (`node_id`, `index`), `React.memo()` performs a fast shallow comparison, safely skipping re-rendering when unnecessary.
📊 Impact: Expected reduction in unnecessary list item re-renders during scrolling and interaction by turning O(N) re-renders into O(1) for unmodified items.
🔬 Measurement: Observe React DevTools Profiler while scrolling rapidly through `QueueEntry` lists or interacting with items; unmodified components should skip rendering.

---
*PR created automatically by Jules for task [6663391916437298597](https://jules.google.com/task/6663391916437298597) started by @kshramt*