### PR TITLE
🎨 Palette: Add ARIA labels and titles to core icon buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -8,11 +8,21 @@ export const DELETE_MARK = <span className="material-icons">close</span>;
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
-export const START_CONCURRNET_MARK = (
-  <span className="material-icons">double_arrow</span>
+export const START_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    play_arrow
+  </span>
 );
-export const ADD_MARK = <span className="material-icons">add</span>;
+export const START_CONCURRNET_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    double_arrow
+  </span>
+);
+export const ADD_MARK = (
+  <span className="material-icons" aria-hidden="true">
+    add
+  </span>
+);
 export const DONE_MARK = <span className="material-icons">done</span>;
 export const DONT_MARK = <span className="material-icons">delete</span>;
 export const DETAIL_MARK = <span className="material-icons">more_vert</span>;


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to three core icon-only buttons (`AddButton`, `StartButton`, `StartConcurrentButton`). Added `aria-hidden="true"` to the underlying `START_MARK`, `START_CONCURRNET_MARK`, and `ADD_MARK` Material Design icons.

### 🎯 Why
Icon-only buttons are inaccessible to screen reader users because they lack an accessible name. Without `aria-hidden="true"`, screen readers will confusingly announce the raw ligature text (e.g., "play arrow" or "double arrow") instead of the button's intended action. The `title` attribute adds visual tooltips for mouse users, improving clarity.

### 📸 Before/After
*   **Before:** `<button class="btn-icon"><span class="material-icons">play_arrow</span></button>` (Announces: "button, play arrow")
*   **After:** `<button class="btn-icon" aria-label="Start" title="Start"><span class="material-icons" aria-hidden="true">play_arrow</span></button>` (Announces: "Start, button")

### ♿ Accessibility
*   Provided an accessible name to interactive elements.
*   Prevented redundant and confusing ligature text from being announced by screen readers.
*   Improved discoverability for sighted users via native tooltips.

---
*PR created automatically by Jules for task [3464944439120951958](https://jules.google.com/task/3464944439120951958) started by @kshramt*