### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to api_v2

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-05 - Strict Content Security Policy for Pure JSON APIs
+**Vulnerability:** Missing security headers, specifically CSP, allowed potential execution of unintended content if endpoints were mistakenly accessed or configured to serve HTML.
+**Learning:** For a pure JSON API like `api_v2`, a maximum restrictive CSP (`default-src 'none'; frame-ancestors 'none'; sandbox`) is extremely effective and safe, as the API should strictly serve JSON data and never execute inline scripts or render HTML.
+**Prevention:** Apply a strict CSP middleware globally on Axum routers serving JSON to proactively defend against XSS and clickjacking via unexpected content types.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,36 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: std::sync::Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    app.layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::CONTENT_SECURITY_POLICY,
+        hyper::header::HeaderValue::from_static(
+            "default-src 'none'; frame-ancestors 'none'; sandbox",
+        ),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::STRICT_TRANSPORT_SECURITY,
+        hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::X_FRAME_OPTIONS,
+        hyper::header::HeaderValue::from_static("DENY"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::X_CONTENT_TYPE_OPTIONS,
+        hyper::header::HeaderValue::from_static("nosniff"),
+    ))
+    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+        hyper::header::HeaderName::from_static("referrer-policy"),
+        hyper::header::HeaderValue::from_static("no-referrer"),
+    ))
+    .layer(tower_http::trace::TraceLayer::new_for_http())
+    .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +415,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +425,42 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+        let state = std::sync::Arc::new(AppState::new(0, pool));
+        let app = app(state);
+
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        let headers = response.headers();
+
+        assert_eq!(
+            headers.get(hyper::header::CONTENT_SECURITY_POLICY).unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            headers
+                .get(hyper::header::STRICT_TRANSPORT_SECURITY)
+                .unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
+        assert_eq!(headers.get(hyper::header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            headers.get(hyper::header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(headers.get("referrer-policy").unwrap(), "no-referrer");
+    }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The API lacked standard security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy), increasing the risk of attacks like XSS, clickjacking, MIME-sniffing, and potential data leakage.
🎯 Impact: Even for a JSON API, absent headers can lead to vulnerabilities if the content type is misinterpreted by browsers or if future endpoints inadvertently serve HTML.
🔧 Fix: Implemented a robust `tower_http::set_header::SetResponseHeaderLayer` to uniformly enforce restrictive security headers across all `api_v2` responses, utilizing `default-src 'none'; frame-ancestors 'none'; sandbox` for maximum safety.
✅ Verification: An integration test (`test_security_headers`) was added to `main.rs` to verify the presence and correct values of these headers without needing a live database. Tests were successfully run (`cargo test`).

---
*PR created automatically by Jules for task [11170705037682136456](https://jules.google.com/task/11170705037682136456) started by @kshramt*