### PR TITLE
⚡ Bolt: Optimize QueueEntry rendering performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - React.memo for Virtuoso lists
+**Learning:** List items like `QueueEntry` and `MobileQueueNode` that take simple primitive props (`node_id`, `index`) are prime candidates for `React.memo()`. By default, they re-render whenever the parent virtualized list (`react-virtuoso`) re-renders, causing unnecessary O(N) operations during scrolling and state updates.
+**Action:** Always check list item components passed into mapping functions or virtualized list renderers. If they only receive primitives, wrap them in `React.memo()` and set `.displayName` to prevent performance bottlenecks.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,7 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +29,8 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,7 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,7 +1235,8 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
 const TreeEntry = (props: {
   node_id: types.TNodeId;


### PR DESCRIPTION
💡 **What:** Wrapped `QueueEntry` and `MobileQueueNode` components with `React.memo()`. Set their `displayName` properties for debugging clarity.
🎯 **Why:** Both components are used inside lists (e.g., virtualized lists via `react-virtuoso` or standard maps). Without `React.memo()`, these components re-render every time their parent container re-renders, causing unnecessary processing across the visible items (O(N) operation). Since they only receive primitive props (`node_id`, `index`, `nodeId`), shallow prop comparison allows them to safely skip rendering.
📊 **Impact:** Reduces React render cycles for visible queue entries during unrelated state updates in parent components or when scrolling virtualized lists.
🔬 **Measurement:** Verify with React DevTools Profiler that `QueueEntry` and `MobileQueueNode` instances correctly bailout of rendering when their specific props have not changed.

---
*PR created automatically by Jules for task [15721685930199621515](https://jules.google.com/task/15721685930199621515) started by @kshramt*