### PR TITLE
🎨 Palette: Improve accessibility of StartButton and UI icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-05 - Material UI Icon Ligatures and Screen Readers
+**Learning:** Material UI icon spans (e.g., `<span className="material-icons">`) use text ligatures (e.g., "play_arrow") to render icons. Screen readers will incorrectly announce this ligature text (e.g., reading "play underscore arrow" instead of the button's action) unless the span has `aria-hidden="true"`.
+**Action:** Always add `aria-hidden="true"` to Material UI icon spans, and ensure the parent interactive element (like a button) has a descriptive `aria-label` or `title`.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -16,6 +16,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
     <button
       className="btn-icon"
       onClick={on_click}
+      aria-label="Start"
+      title="Start"
       onDoubleClick={utils.prevent_propagation}
     >
       {consts.START_MARK}

--- a/client/src/consts.tsx
+++ b/client/src/consts.tsx
@@ -4,40 +4,128 @@ export const MINUTE = 60 * 1_000;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
 
-export const DELETE_MARK = <span className="material-icons">close</span>;
+export const DELETE_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    close
+  </span>
+);
 
 export const NO_ESTIMATION = 0;
 
-export const START_MARK = <span className="material-icons">play_arrow</span>;
+export const START_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    play_arrow
+  </span>
+);
 export const START_CONCURRNET_MARK = (
-  <span className="material-icons">double_arrow</span>
+  <span aria-hidden="true" className="material-icons">
+    double_arrow
+  </span>
 );
-export const ADD_MARK = <span className="material-icons">add</span>;
-export const DONE_MARK = <span className="material-icons">done</span>;
-export const DONT_MARK = <span className="material-icons">delete</span>;
-export const DETAIL_MARK = <span className="material-icons">more_vert</span>;
-export const COPY_MARK = <span className="material-icons">content_copy</span>;
-export const STOP_MARK = <span className="material-icons">stop</span>;
-export const TOP_MARK = <span className="material-icons">arrow_upward</span>;
-export const UNDO_MARK = <span className="material-icons">undo</span>;
-export const MOVE_UP_MARK = <span className="material-icons">north</span>;
-export const MOVE_DOWN_MARK = <span className="material-icons">south</span>;
-export const EVAL_MARK = <span className="material-icons">functions</span>;
-export const TOC_MARK = <span className="material-icons">toc</span>;
+export const ADD_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    add
+  </span>
+);
+export const DONE_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    done
+  </span>
+);
+export const DONT_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    delete
+  </span>
+);
+export const DETAIL_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    more_vert
+  </span>
+);
+export const COPY_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    content_copy
+  </span>
+);
+export const STOP_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    stop
+  </span>
+);
+export const TOP_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    arrow_upward
+  </span>
+);
+export const UNDO_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    undo
+  </span>
+);
+export const MOVE_UP_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    north
+  </span>
+);
+export const MOVE_DOWN_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    south
+  </span>
+);
+export const EVAL_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    functions
+  </span>
+);
+export const TOC_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    toc
+  </span>
+);
 export const FORWARD_MARK = (
-  <span className="material-icons">arrow_forward_ios</span>
+  <span aria-hidden="true" className="material-icons">
+    arrow_forward_ios
+  </span>
 );
-export const BACK_MARK = <span className="material-icons">arrow_back_ios</span>;
-export const SEARCH_MARK = <span className="material-icons">search</span>;
-export const IDS_MARK = <span className="material-icons">content_paste</span>;
-export const MOBILE_MARK = <span className="material-icons">smartphone</span>;
+export const BACK_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    arrow_back_ios
+  </span>
+);
+export const SEARCH_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    search
+  </span>
+);
+export const IDS_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    content_paste
+  </span>
+);
+export const MOBILE_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    smartphone
+  </span>
+);
 export const DESKTOP_MARK = (
-  <span className="material-icons">desktop_windows</span>
+  <span aria-hidden="true" className="material-icons">
+    desktop_windows
+  </span>
 );
-export const IS_FULL_MARK = <span className="material-icons">expand_more</span>;
-export const IS_NONE_MARK = <span className="material-icons">expand_less</span>;
+export const IS_FULL_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    expand_more
+  </span>
+);
+export const IS_NONE_MARK = (
+  <span aria-hidden="true" className="material-icons">
+    expand_less
+  </span>
+);
 export const IS_PARTIAL_MARK = (
-  <span className="material-icons">chevron_right</span>
+  <span aria-hidden="true" className="material-icons">
+    chevron_right
+  </span>
 );
 
 export const SPINNER = (


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` to the `StartButton` component, and added `aria-hidden="true"` to all Material UI icon spans in `client/src/consts.tsx`.
🎯 Why: Material UI ligature icons (e.g., `play_arrow`) are incorrectly announced by screen readers if not hidden. Icon-only buttons like `StartButton` must have descriptive text via `aria-label` to be accessible, and a `title` provides a helpful tooltip for visual users.
📸 Before/After: Not applicable (invisible UX/a11y changes).
♿ Accessibility: Ensures the `StartButton` and standard UI marks are properly read by screen readers without announcing the raw Material UI ligature strings.

---
*PR created automatically by Jules for task [12962677647392268620](https://jules.google.com/task/12962677647392268620) started by @kshramt*