### PR TITLE
🎨 Palette: Add accessible names to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-05-20 - Icon-only Buttons Missing Accessible Names
+
+**Learning:** When using Material UI icon ligatures (e.g., `<span className="material-icons">play_arrow</span>`), the ligatures cause screen readers to announce the ligature text ("play arrow") instead of the function. And if `aria-hidden="true"` is applied to the icon, the parent button will lack an accessible name if it doesn't have an `aria-label` or `title`.
+
+**Action:** Add descriptive `aria-label` and `title` attributes to all icon-only buttons across the app to ensure proper screen reader accessibility and provide visual tooltips on hover. Ensure `aria-hidden="true"` is on the icon element itself.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,10 +29,14 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >
-      {consts.ADD_MARK}
+      <span className="material-icons" aria-hidden="true">
+        add
+      </span>
     </button>
   );
 };

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import * as actions from "src/actions";
-import * as consts from "src/consts";
 import * as types from "src/types";
 import * as utils from "src/utils";
 

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,10 +15,14 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >
-      {consts.START_MARK}
+      <span className="material-icons" aria-hidden="true">
+        play_arrow
+      </span>
     </button>
   );
 };

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import * as actions from "src/actions";
-import * as consts from "src/consts";
 import * as types from "src/types";
 import * as utils from "src/utils";
 

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,10 +15,14 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >
-      {consts.START_CONCURRNET_MARK}
+      <span className="material-icons" aria-hidden="true">
+        double_arrow
+      </span>
     </button>
   );
 };

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,10 +16,14 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
+      title="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >
-      {consts.DONE_MARK}
+      <span className="material-icons" aria-hidden="true">
+        done
+      </span>
     </button>
   );
 };

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import * as actions from "./actions";
-import * as consts from "./consts";
 import { useDispatch } from "./types";
 import * as types from "./types";
 import * as utils from "./utils";

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import * as actions from "src/actions";
-import * as consts from "src/consts";
 import * as types from "src/types";
 import * as utils from "src/utils";
 

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,11 +13,15 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to top"
+      title="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}
     >
-      {consts.TOP_MARK}
+      <span className="material-icons" aria-hidden="true">
+        arrow_upward
+      </span>
     </button>
   );
 };


### PR DESCRIPTION
💡 What: Replaced shared string constants with inline accessible icon markup and added aria-label and title attributes to multiple icon-only interactive buttons (Add, Start, StartConcurrent, Top, Mark as Done).

🎯 Why: Material Icon ligatures (e.g., "play_arrow") are read out loud by screen readers when missing `aria-hidden="true"`. Furthermore, these icon-only buttons lacked descriptive `aria-label`s, meaning screen readers did not know their true purpose.

📸 Before/After: Visual tooltips (titles) now show on hover.
♿ Accessibility:
- Added `aria-label` attributes to the buttons so screen readers can announce their purpose correctly.
- Added `aria-hidden="true"` to the internal `span` elements to hide the confusing ligature text from screen readers.

---
*PR created automatically by Jules for task [17223282961375603913](https://jules.google.com/task/17223282961375603913) started by @kshramt*