### PR TITLE
🛡️ Sentinel: [security improvement] Add strict HTTP security headers to API v2 router

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-06 - Extracting Axum router for testability
+
+**Learning:** When testing Axum router logic (like middleware) in `api_v2`, place tests directly inline within `api_v2/src/main.rs` inside a `#[cfg(test)] mod tests { ... }` block rather than creating separate files in `api_v2/tests/`. To facilitate this without duplicating middleware layer configuration, the Axum router setup should be extracted into a standalone function (`pub fn app(state: Arc<AppState>) -> axum::Router`) that can be instantiated by both `main` and test modules.
+**Action:** Always extract the Axum app router creation to a public function when adding testable server configuration (like security headers).

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,9 +338,9 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
-    id_generator: Mutex<id_generator::SortableIdGenerator>,
-    pool: sqlx::postgres::PgPool,
+pub struct AppState {
+    pub id_generator: Mutex<id_generator::SortableIdGenerator>,
+    pub pool: sqlx::postgres::PgPool,
 }
 impl AppState {
     pub fn new(shard: u16, pool: sqlx::postgres::PgPool) -> Self {
@@ -378,6 +378,40 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: std::sync::Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+
+    // Add strict security headers
+    let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            axum::http::HeaderValue::from_static("strict-origin-when-cross-origin"),
+        ));
+
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +419,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);
@@ -400,4 +429,49 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_security_headers() {
+        // Initialize AppState with a dummy DB connection for testing
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@localhost/invalid")
+            .unwrap();
+        let state = std::sync::Arc::new(AppState::new(0, pool));
+
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri("/")
+            .method("GET")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        // Verify security headers
+        assert_eq!(
+            response.headers().get("content-security-policy").unwrap(),
+            "default-src 'none'; frame-ancestors 'none'; sandbox"
+        );
+        assert_eq!(
+            response.headers().get("strict-transport-security").unwrap(),
+            "max-age=31536000; includeSubDomains; preload"
+        );
+        assert_eq!(response.headers().get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(
+            response.headers().get("x-content-type-options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            response.headers().get("referrer-policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+    }
 }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The API v2 Axum server lacked strict HTTP security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy). Without these, the API could be vulnerable to clickjacking, MIME-type sniffing, or missing TLS enforcement for modern web security standards.
🎯 **Impact:** Potential for browsers to misinterpret API responses or permit framing, exposing endpoints to basic web-based attacks depending on client integration.
🔧 **Fix:** Extracted the Axum router creation into a standalone `app` function to allow testability. Added `tower_http::set_header::SetResponseHeaderLayer` middleware to enforce `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`. Wrote an inline test module using `tower::ServiceExt` to simulate an HTTP GET request and verify the presence of these security headers.
✅ **Verification:** Run `cargo test` in the `api_v2` directory to verify the inline tests pass and the security headers are correctly applied.

---
*PR created automatically by Jules for task [279508024417027629](https://jules.google.com/task/279508024417027629) started by @kshramt*