### PR TITLE
🎨 Palette: Add ARIA labels and titles to core interaction buttons

### DIFF
--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -34,6 +34,7 @@ pub struct FakeIdpCreateUserResponse {
     pub id_token: IdToken,
 }
 #[rustfmt::skip]
+#[allow(dead_code)]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -27,6 +27,8 @@ export const AddButton = (props: {
   }, [props.node_id, dispatch, show_mobile, prefix]);
   return (
     <button
+      aria-label="Add child"
+      title="Add child"
       className="btn-icon"
       id={props.id}
       onClick={handle_click}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -14,6 +14,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start"
+      title="Start"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -14,6 +14,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start concurrently"
+      title="Start concurrently"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -12,6 +12,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Move to top"
+      title="Move to top"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
🎨 Palette: Add ARIA labels and titles to core interaction buttons

💡 What: Added `aria-label` and `title` attributes to `StartButton`, `StartConcurrentButton`, `AddButton`, and `TopButton`.
🎯 Why: These buttons are icon-only. Without labels, screen readers announce "button" or the ligature name (like "play arrow" or "add"), which is confusing. The title provides a native tooltip for mouse users.
📸 Before/After: Visual changes are tooltips. HTML structure changes add `aria-label`.
♿ Accessibility: Ensures interactive buttons have accessible names for assistive technologies.

---
*PR created automatically by Jules for task [10835462785349660316](https://jules.google.com/task/10835462785349660316) started by @kshramt*