### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to API

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
## 🛡️ Sentinel: [security improvement] Add security headers to API

**Severity:** MEDIUM
**Vulnerability:** Missing HTTP security headers. Without these, the application lacks a secondary layer of defense against attacks like MIME-sniffing, clickjacking, and man-in-the-middle downgrade attacks.
**Impact:** While primarily an API backend, missing these standard headers fails to follow best-practice defense-in-depth principles. For example, if a client accidentally treats a JSON response as HTML, lack of CSP and X-Content-Type-Options could lead to XSS.
**Fix:** Injected 5 standard security headers into the `api_v2` Axum routing layer using `tower-http::set_header::SetResponseHeaderLayer`.
**Verification:** The headers are correctly implemented and compilation passes. The test suites for both frontend and backend continue to pass successfully.

---
*PR created automatically by Jules for task [9162875214657016125](https://jules.google.com/task/9162875214657016125) started by @kshramt*