### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP security headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 # production
 **/build/
+**/dist/
+**/dev-dist/
 
 # misc
 .DS_Store

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-12 - Secure HTTP Headers via Middleware
+**Vulnerability:** Missing basic security headers.
+**Learning:** In Rust with Axum and `tower-http`, do not chain `.overriding()` calls to configure multiple headers using the same generic `SetResponseHeaderLayer` instantiation as each overriding creates a new layer instance. Also, frontend artifacts should not be committed.
+**Prevention:** Apply each security header in its own separate middleware layer wrapping the router. Verify `.gitignore` prevents artifacts from being tracked during testing.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -389,6 +389,28 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard HTTP security headers
🎯 Impact: Without strict HTTP security headers like HSTS, CSP, and X-Frame-Options, the application is at a higher baseline risk for client-side attacks such as clickjacking, MIME sniffing, and cross-site scripting (XSS).
🔧 Fix: Configured `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs` to add `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and a restrictive `Content-Security-Policy`. Added strict exclusions to `.gitignore` to prevent generated artifacts from tracking.
✅ Verification: Ran `git diff`, `cargo test`, `cargo clippy`, and frontend build pipeline. Validated that all frontend test suites successfully execute.

---
*PR created automatically by Jules for task [10236170007059925506](https://jules.google.com/task/10236170007059925506) started by @kshramt*