### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
**💡 What:** Added `aria-label` and `title` attributes to `StartButton`, `StartConcurrentButton`, and `AddButton`.
**🎯 Why:** These are icon-only buttons. Without accessible names, screen readers cannot properly announce their function, hindering accessibility. The title attribute provides a helpful tooltip for mouse users.
**📸 Before/After:** Screen readers announce these buttons clearly as "Start", "Start concurrently", and "Add" instead of generic button text or ignoring them. Sighted users now see tooltips on hover.
**♿ Accessibility:** Improves WCAG compliance by ensuring icon-only interactive controls have an accessible name.

---
*PR created automatically by Jules for task [17339799402975090244](https://jules.google.com/task/17339799402975090244) started by @kshramt*