### PR TITLE
🛡️ Sentinel: [HIGH] Fix Missing security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-13 - Add security headers to axum router
+**Vulnerability:** The `api_v2` Axum backend was missing critical security headers, making it potentially vulnerable to basic web attacks if endpoints were accessed directly.
+**Learning:** Axum's `tower_http::set_header::SetResponseHeaderLayer::overriding()` does not support chaining directly for multiple headers. Instead, multiple `.layer()` calls are required on the Axum router, each with a single header configuration. Additionally, the `hyper::header` module should be used instead of the `http` crate for header definitions. Non-standard headers like `Referrer-Policy` require `HeaderName::from_static`.
+**Prevention:** Always verify that security headers (like CSP, HSTS, X-Frame-Options) are applied correctly using the appropriate layer composition pattern when setting up new Axum routers or modifying existing ones.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -389,6 +389,26 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing security headers on the backend API made it potentially susceptible to MIME sniffing, clickjacking, and XSS.
🎯 Impact: Exploitation of these vulnerabilities could lead to data exfiltration or unauthorized actions if an endpoint is accessed directly or embedded in an iframe.
🔧 Fix: Added a series of `SetResponseHeaderLayer` calls to the Axum Router in `api_v2/src/main.rs`. We added:
- `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; sandbox`
- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
- `X-Frame-Options: DENY`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: no-referrer`
✅ Verification: Tested locally with `cargo test` in the backend. Evaluated with `make check` on the frontend. The router configurations were verified visually.

---
*PR created automatically by Jules for task [8048511983311202233](https://jules.google.com/task/8048511983311202233) started by @kshramt*