### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -27,6 +27,8 @@ export const AddButton = (props: {
   }, [props.node_id, dispatch, show_mobile, prefix]);
   return (
     <button
+      aria-label="Add"
+      title="Add"
       className="btn-icon"
       id={props.id}
       onClick={handle_click}

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -57,6 +57,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move up"
+      title="Move up"
       className="btn-icon"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
@@ -76,6 +78,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move down"
+      title="Move down"
       className="btn-icon"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -14,6 +14,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start"
+      title="Start"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -14,6 +14,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start concurrently"
+      title="Start concurrently"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to `<button>` elements in `AddButton`, `StartButton`, `StartConcurrentButton`, `EntryButtons` (Move Up/Move Down).
🎯 **Why:** Icon-only buttons without an explicit accessible name are completely invisible or misread by screen readers. Furthermore, adding the `title` attribute gives sighted users native browser tooltips to understand the button's action without guesswork.
📸 **Before/After:** Before, the buttons relied strictly on the Material Icons content which isn't always descriptive via screen readers. Now, they have explicit `aria-label="Start"` etc.
♿ **Accessibility:** Fixes severe WCAG 4.1.2 (Name, Role, Value) violations by ensuring icon buttons have a clear, accessible name.

---
*PR created automatically by Jules for task [163552022940516271](https://jules.google.com/task/163552022940516271) started by @kshramt*