### PR TITLE
🛡️ Sentinel: [security improvement] Add strict API security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-05-16 - API Security Headers Extracted
+
+**Vulnerability:** Missing defense-in-depth HTTP security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) on API endpoints. While the API only returns JSON, setting a strict CSP (`default-src 'none'`) and preventing MIME-sniffing mitigates browser-based attacks.
+**Learning:** The `api_v2` Axum router was initially defined directly in `main`, making it difficult to inject globally scoped `tower_http` middleware while keeping the router easily testable. Additionally, extracting the router into a public function required changing the visibility of the internal `AppState` struct to `pub`.
+**Prevention:** Always extract application router configurations into a standalone, testable `pub fn app(state) -> axum::Router` function. Use `tower_http::set_header` layer explicitly with fully qualified paths to inject secure HTTP headers universally across all routes during configuration.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -338,7 +338,7 @@ async fn create_client(
 }
 
 #[derive(Debug)]
-struct AppState {
+pub struct AppState {
     id_generator: Mutex<id_generator::SortableIdGenerator>,
     pool: sqlx::postgres::PgPool,
 }
@@ -378,6 +378,37 @@ async fn get_pool() -> sqlx::postgres::PgPool {
         .unwrap()
 }
 
+pub fn app(state: std::sync::Arc<AppState>) -> axum::Router {
+    let app = axum::Router::new();
+    let app = gen::register_app::<ApiImpl>(app);
+    let app = app.with_state(state);
+    let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ));
+    app.layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -385,12 +416,7 @@ async fn main() {
         .json()
         .init();
     let state = std::sync::Arc::new(AppState::new(get_shard(), get_pool().await));
-    let app = axum::Router::new();
-    let app = gen::register_app::<ApiImpl>(app);
-    let app = app.with_state(state);
-    let app = app
-        .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+    let app = app(state);
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The API endpoints were missing defense-in-depth HTTP security headers (such as Content-Security-Policy, Strict-Transport-Security, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy).
🎯 **Impact:** Without these headers, clients interacting with the API are more susceptible to browser-based attacks like cross-site scripting (XSS), MIME-sniffing, and clickjacking, even though the API primarily serves JSON.
🔧 **Fix:** Extracted the Axum router configuration into a testable `pub fn app()` function. Added a sequence of `tower_http::set_header::SetResponseHeaderLayer` middleware to inject strict security header values on every request. Included a tight CSP (`default-src 'none'; frame-ancestors 'none'; sandbox`). Also adjusted `AppState` visibility to `pub` and added `#[allow(dead_code)]` to an unused generated struct to ensure compilation and linting pass.
✅ **Verification:** Verified by running `cargo clippy`, `cargo fmt`, and `cargo test` in the `api_v2` directory. Evaluated frontend test checks to ensure no collateral build breakage.

---
*PR created automatically by Jules for task [16558824825900607703](https://jules.google.com/task/16558824825900607703) started by @kshramt*