### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Missing Security Headers in api_v2
+**Vulnerability:** The Rust/Axum API (`api_v2`) lacks standard security headers such as `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`.
+**Learning:** Security headers should be explicitly configured in the Axum router using `tower_http::set_header::SetResponseHeaderLayer`. Since Axum does not include them by default, failure to configure these leaves the API open to potential clickjacking, MIME-type sniffing, and other web-based attacks.
+**Prevention:** Ensure any new service endpoints or router instances apply common security headers via `tower_http` middlewares.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The Rust/Axum API (`api_v2`) was missing standard security headers such as `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`.
🎯 **Impact**: Without these headers, the API could be vulnerable to cross-site scripting (XSS), clickjacking, MIME-type sniffing attacks, and unintentional referrer leaking.
🔧 **Fix**: Configured explicit security response headers using `tower_http::set_header::SetResponseHeaderLayer` in the Axum application router in `api_v2/src/main.rs`.
✅ **Verification**: Run `cargo check` and `cargo test` in `api_v2`, and visually verify the applied `tower_http` layers via the codebase source file.

---
*PR created automatically by Jules for task [10624155480797391191](https://jules.google.com/task/10624155480797391191) started by @kshramt*