### PR TITLE
🎨 Palette: Add ARIA labels to core icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Icon-only Button Accessibility
+**Learning:** This codebase relies heavily on `<span className="material-icons">` inside `<button className="btn-icon">` for actionable buttons (e.g., Add, Start, StartConcurrent, MoveUp, MoveDown). This pattern, without explicit accessible names, makes the core functionality invisible to screen readers and difficult to discover for new users since visual tooltips are also missing.
+**Action:** When creating new icon-only buttons or reviewing existing ones, always ensure `aria-label` and `title` attributes are provided to make the actions accessible and discoverable.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add"
+      title="Add"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up"
+      title="Move up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down"
+      title="Move down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrent"
+      title="Start concurrent"
     >
       {consts.START_CONCURRNET_MARK}
     </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to key icon-only buttons (`AddButton`, `StartButton`, `StartConcurrentButton`, `MoveUpButton`, `MoveDownButton`).
🎯 **Why:** To improve accessibility for screen readers and provide helpful native tooltips for visual users, making the interface more discoverable and intuitive.
📸 **Before/After:** Icon-only buttons previously lacked accessible names and visual tooltips. They now provide native tooltips on hover and properly announce their actions to assistive technologies.
♿ **Accessibility:** Solves a major accessibility gap where screen readers would either announce nothing or announce the ligature text (e.g., "add", "play arrow") instead of the semantic action. The addition of explicit labels ensures clear communication of the button's purpose.

---
*PR created automatically by Jules for task [4838249015131007420](https://jules.google.com/task/4838249015131007420) started by @kshramt*