### PR TITLE
🎨 Palette: [UX improvement] Add aria-label and title to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Added ARIA labels to core Action Buttons
+**Learning:** This app's core interaction model relies heavily on icon-only action buttons (e.g., `AddButton`, `StartButton`, `MoveUpButton`) rendered dynamically within virtualized list entries (via `EntryButtons`). These components universally lacked `aria-label` and `title` attributes, making them inaccessible to screen readers and difficult for keyboard/mouse users to identify without prior context.
+**Action:** When adding new icon-only buttons to the interface, always ensure they are explicitly provided with `aria-label` and `title` attributes using static string values representing their action, as relying on the React node children (e.g., `consts.ADD_MARK`) will fail to provide accessible names.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -27,6 +27,8 @@ export const AddButton = (props: {
   }, [props.node_id, dispatch, show_mobile, prefix]);
   return (
     <button
+      aria-label="Add"
+      title="Add"
       className="btn-icon"
       id={props.id}
       onClick={handle_click}

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -57,6 +57,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move Up"
+      title="Move Up"
       className="btn-icon"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
@@ -76,6 +78,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
 
   return (
     <button
+      aria-label="Move Down"
+      title="Move Down"
       className="btn-icon"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -14,6 +14,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start"
+      title="Start"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -14,6 +14,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   }, [props.node_id, dispatch]);
   return (
     <button
+      aria-label="Start Concurrently"
+      title="Start Concurrently"
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to icon-only action buttons across the application, specifically `StartButton`, `StartConcurrentButton`, `AddButton`, `MoveUpButton`, and `MoveDownButton`.

🎯 **Why:** Icon-only buttons without accessible names are invisible or confusing to screen readers, and lack tooltip hints for sighted users. Adding these attributes makes the interface significantly more intuitive and fully accessible.

♿ **Accessibility:** 
- Provides explicit, readable text alternatives for screen readers interacting with core list action items.
- Adds native tooltip hints (`title`) for users hovering over the icons, reducing cognitive load when identifying actions.

---
*PR created automatically by Jules for task [8888988991986501987](https://jules.google.com/task/8888988991986501987) started by @kshramt*