### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and titles to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Adding ARIA labels to Icon-only Buttons
+**Learning:** React elements displaying raw material icons (like `{consts.START_MARK}`) within buttons can be completely ignored by screen readers, making the application inaccessible to keyboard and screen reader users. The `btn-icon` instances often lack textual representation.
+**Action:** When adding or updating icon-only buttons (`btn-icon`), always ensure they are paired with `aria-label` and `title` attributes that meaningfully describe the button's action.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,8 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add"
+      title="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move up"
+      title="Move up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +79,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move down"
+      title="Move down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to `StartButton`, `StartConcurrentButton`, `AddButton`, `MoveUpButton` and `MoveDownButton` which were previously lacking accessible names. Added a journal entry about this to `.Jules/palette.md`.
🎯 Why: Screen readers cannot infer the meaning of a button containing only a material icon element (like `{consts.START_MARK}`). These labels make the application accessible to keyboard and screen reader users and add helpful browser tooltips.
📸 Before/After: Visual changes are invisible DOM-level attributes. Tooltips now appear on hover.
♿ Accessibility: Ensures interactive buttons with icon-only contents have proper textual representation.

---
*PR created automatically by Jules for task [12802291996476748994](https://jules.google.com/task/12802291996476748994) started by @kshramt*