### PR TITLE
🛡️ Sentinel: [security improvement] Add strict security headers

### DIFF
--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -33,6 +33,7 @@ pub struct FakeIdpCreateUserRequest {
 pub struct FakeIdpCreateUserResponse {
     pub id_token: IdToken,
 }
+#[allow(dead_code)]
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct FakeIdpCreateIdTokenRequest {

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -8,11 +8,13 @@ use axum_extra::{
     TypedHeader,
 };
 use base64::Engine;
+use hyper::header;
 use serde_json::json;
 use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
@@ -390,7 +392,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🛡️ Sentinel: Add strict security headers to Axum router

- Added standard security headers (Content-Security-Policy, Strict-Transport-Security, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) to the `api_v2` Axum application using `tower_http::set_header::SetResponseHeaderLayer`.
- This enforces strict security measures (e.g., preventing MIME-sniffing, clickjacking) across all API responses.
- Fixed a clippy warning for an unused generated struct (`FakeIdpCreateIdTokenRequest`).

---
*PR created automatically by Jules for task [4030560982695413069](https://jules.google.com/task/4030560982695413069) started by @kshramt*