### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and titles to icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move up"
+      title="Move up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +79,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move down"
+      title="Move down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `title` attributes to icon-only buttons (`AddButton`, `StartButton`, `StartConcurrentButton`, `MoveUpButton`, `MoveDownButton`).
🎯 **Why**: To improve accessibility for screen readers and provide helpful tooltips for sighted users navigating the interface.
📸 **Before/After**: Buttons now have standard browser tooltips on hover and announce their purpose to assistive technologies.
♿ **Accessibility**: ARIA labels ensure screen reader compatibility for interactive elements without text content.

---
*PR created automatically by Jules for task [12464679628397068645](https://jules.google.com/task/12464679628397068645) started by @kshramt*