### PR TITLE
🎨 Palette: Accessibility improvement for icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-22 - Accessibility for icon-only buttons
+**Learning:** Icon-only buttons must include both `aria-label` (for screen readers) and `title` (for visual tooltips on hover) attributes to ensure full accessibility and usability for all users.
+**Action:** Always add `aria-label` and `title` attributes when creating or modifying icon-only buttons.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add sub-task"
+      title="Add sub-task"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up"
+      title="Move up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down"
+      title="Move down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrently"
+      title="Start concurrently"
     >
       {consts.START_CONCURRNET_MARK}
     </button>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to `StartButton`, `StartConcurrentButton`, `AddButton`, and `MoveUpButton`/`MoveDownButton` in `EntryButtons.tsx`.
🎯 Why: These buttons rely entirely on icons (e.g., Material Icons) to convey their purpose. Without an `aria-label`, screen readers may not accurately describe the button's function to users. Additionally, without a `title`, visually capable users lack a tooltip to understand the icon's meaning on hover.
📸 Before/After: Visual tooltips will now appear when hovering over these buttons, and screen readers will announce their functions correctly.
♿ Accessibility: Ensures WCAG compliance by providing textual alternatives for icon-only interactive elements.

---
*PR created automatically by Jules for task [17237025569268793338](https://jules.google.com/task/17237025569268793338) started by @kshramt*