### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - Add Strict Security Headers
+**Vulnerability:** Missing strict security headers in Axum API.
+**Learning:** Axum tower-http requires explicitly setting security headers to defend against various web vulnerabilities, notably XSS and clickjacking. When doing so, ensure `hyper::header` values match types Axum expects. Also `FakeIdpCreateIdTokenRequest` is unused in tests, so we had to add `#[allow(dead_code)]`.
+**Prevention:** Apply strict security headers for API by default.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing strict security headers in Axum API. This leaves the API potentially vulnerable to MIME-sniffing, clickjacking, and cross-site scripting (if it ever serves HTML content in the future).
🎯 Impact: Attackers could potentially exploit missing headers to trick the browser into interpreting responses maliciously. While this is primarily an API, applying strict headers is defense-in-depth.
🔧 Fix: Added `tower_http::set_header::SetResponseHeaderLayer` to the Axum router to enforce CSP, HSTS, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy headers. Also added `#[allow(dead_code)]` to an unused generated struct (`FakeIdpCreateIdTokenRequest`) to pass strict linting.
✅ Verification: Ensure the backend builds successfully with `cargo check` and `cargo test`. Future API responses will include these secure headers.

---
*PR created automatically by Jules for task [17542011671017067831](https://jules.google.com/task/17542011671017067831) started by @kshramt*