### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-05-24 - Missing Security Headers
+
+**Vulnerability:** The Axum backend API endpoints lacked basic security headers (e.g., Content-Security-Policy, Strict-Transport-Security, X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+**Learning:** `tower-http` with `features = ["full"]` already allows configuring layers via `SetResponseHeaderLayer::overriding()` with Axum routers. Memory logs should be saved to `.jules` specifically. Using `hyper::header` values mapped perfectly.
+**Prevention:** Include these headers natively in standard middleware setup templates whenever standing up new Axum APIs.

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -35,6 +35,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -8,6 +8,7 @@ use axum_extra::{
     TypedHeader,
 };
 use base64::Engine;
+use hyper::header;
 use serde_json::json;
 use std::{
     net::SocketAddr,
@@ -390,7 +391,27 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::CONTENT_SECURITY_POLICY,
+            header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::STRICT_TRANSPORT_SECURITY,
+            header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::HeaderName::from_static("x-frame-options"),
+            header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            header::HeaderName::from_static("referrer-policy"),
+            header::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Axum backend API endpoints lacked basic defense-in-depth HTTP security headers.
🎯 **Impact:** Without these headers, clients are more susceptible to client-side attacks such as Cross-Site Scripting (XSS), Clickjacking, protocol downgrade attacks, and MIME-type sniffing.
🔧 **Fix:** Added `SetResponseHeaderLayer` middleware to the Axum application router to enforce strict security headers:
- `Content-Security-Policy`
- `Strict-Transport-Security`
- `X-Frame-Options`
- `X-Content-Type-Options`
- `Referrer-Policy`
✅ **Verification:** Verify by running `cargo test` in the `api_v2` directory to ensure the build succeeds, and inspect the API HTTP responses to confirm headers are correctly appended.

---
*PR created automatically by Jules for task [193250118214914958](https://jules.google.com/task/193250118214914958) started by @kshramt*