### PR TITLE
🎨 Palette: Improve accessibility of core action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-25 - Icon-Only Button Accessibility Pattern
+**Learning:** Found a recurring pattern where generic icon-only action buttons (`StartButton`, `AddButton`, etc.) across various component directories lacked explicit `aria-label` and `title` attributes. Adding these globally to the shared icon constants would be wrong (creates duplicate labels if the parent button already has one), so it's critical to add them directly to the `<button>` tags in their respective React components.
+**Action:** Always inspect icon-only components for missing `aria-label` and `title` props. Apply them directly on the interactive HTML element, rather than modifying the underlying static icon definition.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add"
+      title="Add"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up"
+      title="Move up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down"
+      title="Move down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrently"
+      title="Start concurrently"
     >
       {consts.START_CONCURRNET_MARK}
     </button>


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `title` attributes to several icon-only action buttons (`AddButton`, `StartButton`, `StartConcurrentButton`, `MoveUpButton`, `MoveDownButton`).
🎯 **Why**: Icon-only buttons without text content are inaccessible to screen readers and offer no helpful tooltips for sighted users.
📸 **Before/After**: The buttons visually remain the same, but now expose tooltips on hover (e.g., "Add", "Start concurrently") and proper labels for assistive technologies.
♿ **Accessibility**: Significant improvement for screen reader users by exposing clear action intents for primary application interactions.

---
*PR created automatically by Jules for task [17818059308689793621](https://jules.google.com/task/17818059308689793621) started by @kshramt*