### PR TITLE
🎨 Palette: Add accessible labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-26 - Accessible Icon-Only Buttons
+**Learning:** In this application, many core action buttons (e.g., Add, Start, Move Up/Down) are implemented as icon-only `<button>` elements using the `btn-icon` class and Material UI icon components from `consts.tsx`. To ensure screen reader and keyboard user accessibility without relying on global ARIA modifications that might cause regressions, each specific button component must directly receive `aria-label` and `title` attributes describing its action.
+**Action:** When creating or modifying new action buttons using the `btn-icon` class, strictly mandate passing descriptive `aria-label` and `title` string attributes on the `<button>` tag.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add"
+      title="Add"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up"
+      title="Move up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down"
+      title="Move down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrently"
+      title="Start concurrently"
     >
       {consts.START_CONCURRNET_MARK}
     </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to core icon-only action buttons (`AddButton`, `StartButton`, `StartConcurrentButton`, `MoveUpButton`, `MoveDownButton`). Also created a Palette journal entry documenting this pattern.

🎯 **Why:** Icon-only buttons lacking accessible names are a common accessibility issue. By adding descriptive labels, screen reader users can now understand the button's purpose, and mouse/keyboard users receive helpful tooltips on hover/focus, significantly improving overall usability.

📸 **Before/After:** The buttons appear visually identical, but hovering over them now displays native browser tooltips (e.g., "Add", "Start").

♿ **Accessibility:** This directly resolves WCAG 2.1 Success Criterion 4.1.2 Name, Role, Value by providing explicit accessible names for interactive elements that previously relied solely on visual icons.

---
*PR created automatically by Jules for task [4975686174622131782](https://jules.google.com/task/4975686174622131782) started by @kshramt*