### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to API

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-26 - Add Security Response Headers
+**Vulnerability:** The Axum backend API lacked defense-in-depth HTTP security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+**Learning:** Axum's `tower_http::set_header::SetResponseHeaderLayer` can be stacked to apply multiple headers. For the `tower_http` crate, the values used must be `hyper::header::HeaderValue::from_static(...)`.
+**Prevention:** Include security response headers by default using `tower_http` middleware on all Axum routers.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
Added standard security headers to the API to improve defense in depth against common web vulnerabilities.
- Added Content-Security-Policy (locked down as API only serves JSON)
- Added Strict-Transport-Security (HSTS)
- Added X-Frame-Options (DENY)
- Added X-Content-Type-Options (nosniff)
- Added Referrer-Policy (no-referrer)

---
*PR created automatically by Jules for task [974550738801972662](https://jules.google.com/task/974550738801972662) started by @kshramt*