### PR TITLE
🛡️ Sentinel: [security improvement] Add strict HTTP security headers to API endpoints

### DIFF
--- a/api_v2/Cargo.toml
+++ b/api_v2/Cargo.toml
@@ -19,6 +19,6 @@ serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "macros", "uuid", "chrono", "json"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["full"] }
+tower-http = { version = "0.6", features = ["full", "set-header"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -25,6 +25,7 @@ pub struct SysHealthResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateUserRequest {
     pub name: String,
 }
@@ -35,6 +36,7 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -25,7 +25,6 @@ pub struct SysHealthResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
-#[allow(dead_code)]
 pub struct FakeIdpCreateUserRequest {
     pub name: String,
 }
@@ -36,7 +35,6 @@ pub struct FakeIdpCreateUserResponse {
 }
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
-#[allow(dead_code)]
 pub struct FakeIdpCreateIdTokenRequest {
     pub name: String,
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -389,6 +389,26 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -391,7 +392,9 @@ async fn main() {
     let app = app
         .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
             hyper::header::CONTENT_SECURITY_POLICY,
-            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
         ))
         .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
             hyper::header::STRICT_TRANSPORT_SECURITY,


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Add strict HTTP security headers to API endpoints

🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in the backend API (api_v2), leaving it potentially vulnerable to basic browser-based attacks like clickjacking, MIME-sniffing, and Cross-Site Scripting (XSS) if accessed directly.
🎯 Impact: While an API-only service is less susceptible to these than a web frontend, applying strict security headers implements defense-in-depth, ensuring any accidental or malicious rendering of API responses in a browser context is neutered.
🔧 Fix: Wrapped the axum router in `api_v2/src/main.rs` with multiple `tower_http::set_header::SetResponseHeaderLayer::overriding()` layers to enforce strict CSP, HSTS, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy headers. Additionally resolved a linting warning in `api_v2/src/gen.rs`.
✅ Verification: Ran `cargo check`, `cargo test`, `cargo fmt`, and `cargo clippy` in `api_v2` and `vitest` in `client` to ensure no regressions.

---
*PR created automatically by Jules for task [10816231797682840112](https://jules.google.com/task/10816231797682840112) started by @kshramt*