### PR TITLE
🎨 Palette: [UX improvement] Add accessible labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-27 - Icon-only Button Accessibility
+**Learning:** Icon-only buttons using constants (like `consts.ADD_MARK`) are prevalent in the `client/src` components. These buttons inherently lack accessible names, causing screen readers to announce them incorrectly (or not at all). Adding explicit `aria-label` and `title` attributes directly to the `<button>` tags significantly improves accessibility and provides native tooltips for sighted users.
+**Action:** When creating or modifying icon-only buttons, always ensure they have descriptive `aria-label` and `title` attributes. Do not apply `aria-hidden="true"` globally to the icon constants, as this breaks accessibility for buttons lacking explicit labels.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add"
+      title="Add"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -25,6 +25,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Copy node ID"
+      title="Copy node ID"
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -16,6 +16,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Undo"
+      title="Undo"
     >
       {consts.UNDO_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up"
+      title="Move up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down"
+      title="Move down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -17,6 +17,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Evaluate"
+      title="Evaluate"
     >
       {consts.EVAL_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrently"
+      title="Start concurrently"
     >
       {consts.START_CONCURRNET_MARK}
     </button>

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Mark as done"
+      title="Mark as done"
     >
       {consts.DONE_MARK}
     </button>

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Delete"
+      title="Delete"
     >
       {consts.DONT_MARK}
     </button>

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -16,6 +16,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}
+      aria-label="Move to top"
+      title="Move to top"
     >
       {consts.TOP_MARK}
     </button>


### PR DESCRIPTION
**💡 What:** Added `aria-label` and `title` attributes to multiple icon-only buttons across the frontend (`AddButton`, `EvalButton`, `StartButton`, `TopButton`, `TodoToDoneButton`, `DoneOrDontToTodoButton`, `StartConcurrentButton`, `TodoToDontButton`, `CopyNodeIdButton`, `MoveUpButton`, `MoveDownButton`).

**🎯 Why:** Icon-only buttons without accessible names are invisible or confusing to screen reader users. Adding these attributes makes the interface fully accessible to assistive technologies while also providing helpful native tooltips for sighted users.

**📸 Before/After:** N/A (Visuals remain unchanged, but hovering over the buttons now displays a descriptive tooltip).

**♿ Accessibility:** Greatly improves screen reader compatibility by explicitly defining the purpose of interaction points that previously relied entirely on visual icon cues.

---
*PR created automatically by Jules for task [15977498291428863482](https://jules.google.com/task/15977498291428863482) started by @kshramt*