### PR TITLE
🎨 Palette: [UX improvement] Add aria-label and title to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-28 - Missing accessibility attributes for icon-only buttons
+**Learning:** React components implementing icon-only buttons with the `btn-icon` class consistently lack `aria-label` and `title` attributes. This breaks accessibility for screen reader users and missing `title` degrades usability for sighted users.
+**Action:** Always verify new or existing `btn-icon` components have descriptive `aria-label` and `title` attributes (e.g., `aria-label="Add new item" title="Add new item"`).

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add"
+      title="Add"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -16,6 +16,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Undo"
+      title="Undo"
     >
       {consts.UNDO_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up"
+      title="Move up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down"
+      title="Move down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrently"
+      title="Start concurrently"
     >
       {consts.START_CONCURRNET_MARK}
     </button>

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Mark as done"
+      title="Mark as done"
     >
       {consts.DONE_MARK}
     </button>

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Mark as don't do"
+      title="Mark as don't do"
     >
       {consts.DONT_MARK}
     </button>

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -16,6 +16,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}
+      aria-label="Move to top"
+      title="Move to top"
     >
       {consts.TOP_MARK}
     </button>


### PR DESCRIPTION
**💡 What:**
Added `aria-label` and `title` attributes to multiple icon-only buttons (`btn-icon`) across the application, including:
- `StartButton`
- `StartConcurrentButton`
- `AddButton`
- `TopButton`
- `DoneOrDontToTodoButton`
- `TodoToDoneButton`
- `TodoToDontButton`
- `MoveUpButton` and `MoveDownButton` (in `EntryButtons.tsx`)

**🎯 Why:**
Icon-only buttons rely entirely on their visual icon (e.g., `START_MARK`, `ADD_MARK`) to convey meaning. Without explicit `aria-label` attributes, screen readers cannot announce the button's purpose, making the application inaccessible to visually impaired users. Additionally, missing `title` attributes degrade usability for sighted users who rely on tooltips to understand ambiguous icons. This change ensures these interactive elements are fully accessible and intuitive.

**📸 Before/After:**
- **Before:** `<button className="btn-icon">{consts.ADD_MARK}</button>`
- **After:** `<button className="btn-icon" aria-label="Add" title="Add">{consts.ADD_MARK}</button>`

**♿ Accessibility:**
- Improved screen reader support by providing explicit `aria-label` text for critical actions.
- Improved discoverability for all users by adding native browser tooltips via the `title` attribute.

---
*PR created automatically by Jules for task [5146438831593338898](https://jules.google.com/task/5146438831593338898) started by @kshramt*