### PR TITLE
🛡️ Sentinel: [security improvement] Add strict HTTP security headers to api_v2

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [HTTP Security Headers]
+**Vulnerability:** Missing strict HTTP security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) in the Axum API backend could allow attacks like XSS, Clickjacking, or MIME-type sniffing if HTML content were ever served or if browsers act unexpectedly.
+**Learning:** `tower-http` makes it straightforward to add HTTP security headers using `SetResponseHeaderLayer`, but we must be careful to use `hyper::header` values correctly (e.g. `HeaderValue::from_static` and `HeaderName::from_static` for custom ones like referrer-policy).
+**Prevention:** Ensure new services or endpoints are created with a secure baseline of HTTP response headers.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,29 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) in the Axum backend.
🎯 Impact: While primarily an API serving JSON, lacking these headers could expose the application to XSS, Clickjacking, or MIME-type sniffing if any HTML is inadvertently served or interpreted by browsers.
🔧 Fix: Added `tower_http::set_header::SetResponseHeaderLayer` to the axum router in `api_v2/src/main.rs` to enforce strong security defaults.
✅ Verification: Backend unit tests pass, and headers are visible in the API responses.

---
*PR created automatically by Jules for task [17614187866007584287](https://jules.google.com/task/17614187866007584287) started by @kshramt*