### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and tooltips to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-29 - Avoid Stringifying React Nodes in aria-label
+**Learning:** When assigning 'aria-label' or 'title' attributes dynamically (e.g., from component props), ensure the value evaluates to a string. Passing a React Node to these attributes will result in an '[object Object]' stringification bug in the DOM.
+**Action:** Always verify that 'aria-label' and 'title' values are explicit strings when adding them to icon-only buttons or when reading from external constants.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add"
+      title="Add"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -16,6 +16,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Undo"
+      title="Undo"
     >
       {consts.UNDO_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up"
+      title="Move up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down"
+      title="Move down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start Concurrent"
+      title="Start Concurrent"
     >
       {consts.START_CONCURRNET_MARK}
     </button>

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Mark as Done"
+      title="Mark as Done"
     >
       {consts.DONE_MARK}
     </button>

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Delete"
+      title="Delete"
     >
       {consts.DONT_MARK}
     </button>


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `title` attributes to icon-only buttons across the application (Add, Start, Start Concurrent, Undo, Mark as Done, Delete, Move Up, Move Down).
🎯 **Why**: Icon-only buttons lack context for screen reader users and users navigating via keyboard. Tooltips also provide immediate visual context for sighted users on hover.
♿ **Accessibility**: Significant improvement for screen reader compatibility by explicitly labeling the action for buttons that previously only contained a React Node representing an icon.

---
*PR created automatically by Jules for task [4799252011745584212](https://jules.google.com/task/4799252011745584212) started by @kshramt*