### PR TITLE
🛡️ Sentinel: [security improvement] Add strict HTTP security headers to API

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,6 +390,26 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ))
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 
     let port = get_server_port();

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -392,7 +392,9 @@ async fn main() {
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
             hyper::header::CONTENT_SECURITY_POLICY,
-            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
         ))
         .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
             hyper::header::STRICT_TRANSPORT_SECURITY,


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Missing strict HTTP security headers on the backend JSON API endpoint. While this is primarily an API and not rendering HTML, the lack of headers could allow browsers visiting the API directly (or attackers framing the endpoints) to execute unintended content types or leak referral information.
🎯 **Impact**: Missing `Content-Security-Policy` and `X-Content-Type-Options` could lead to potential MIME-sniffing or limited injection vectors if a browser directly loads an API response. Missing `X-Frame-Options` allows the API responses to be framed.
🔧 **Fix**: Configured the Axum router in `api_v2/src/main.rs` to enforce strong HTTP security headers via `tower_http::set_header::SetResponseHeaderLayer`. Since this is a JSON API, we can safely apply the most restrictive rules, including `default-src 'none'` for CSP and `DENY` for frame options.
✅ **Verification**: Run `curl -I http://localhost:<port>/<endpoint>` against the local backend to verify headers are present in the response. I've successfully validated that the axum application compiles and passes all test suites.

---
*PR created automatically by Jules for task [10522641931984459784](https://jules.google.com/task/10522641931984459784) started by @kshramt*