### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [Security Headers with axum and tower_http]
+**Vulnerability:** Missing strict HTTP security headers.
+**Learning:** Adding `Content-Security-Policy` with `default-src 'none'` is safe on the API endpoints since they only return JSON and aren't rendering HTML, while adding it broadly might break an application that serves UI from the same place. Here, it is safe as Nginx serves the UI and API serves JSON.
+**Prevention:** Make sure `tower-http` with `set-header` is configured correctly on the global router.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,27 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("no-referrer"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -393,7 +393,9 @@ async fn main() {
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
         .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
             hyper::header::CONTENT_SECURITY_POLICY,
-            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'; sandbox"),
+            hyper::header::HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none'; sandbox",
+            ),
         ))
         .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
             hyper::header::STRICT_TRANSPORT_SECURITY,

--- a/test_csp.sh
+++ b/test_csp.sh
@@ -1,0 +1,1 @@
+echo "Testing if client/dist is served by NGINX"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Missing strict HTTP security headers. The API endpoints were returning responses without baseline security headers, leaving clients open to potential attack vectors like MIME-sniffing, clickjacking (if HTML was ever served), and missing HSTS protection.
🎯 **Impact:** Prevents browsers from sniffing content types, forces HTTPS, prevents the API from being embedded in iframes, and strips referrers on outbound links. A strict CSP (`default-src 'none'`) is safe because the API only serves JSON data.
🔧 **Fix:** Configured `tower_http::set_header::SetResponseHeaderLayer` in the global axum Router to append the recommended security headers.
✅ **Verification:** Verified by compiling and running `cargo test`.

---
*PR created automatically by Jules for task [3497944539259816459](https://jules.google.com/task/3497944539259816459) started by @kshramt*