### PR TITLE
🎨 Palette: Add ARIA labels and titles to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-03 - Add ARIA labels and titles to icon-only buttons
+**Learning:** Found multiple icon-only buttons without explicit accessibility labels (aria-label) and visual tooltips (title), which can hinder screen reader accessibility.
+**Action:** When creating icon-only buttons using constants like START_MARK or STOP_MARK, explicitly include `aria-label` for screen readers and `title` for hover tooltips to ensure a more accessible UX.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add"
+      title="Add"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -25,6 +25,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Copy node id"
+      title="Copy node id"
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -16,6 +16,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Undo"
+      title="Undo"
     >
       {consts.UNDO_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up"
+      title="Move up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down"
+      title="Move down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -17,6 +17,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Eval"
+      title="Eval"
     >
       {consts.EVAL_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrently"
+      title="Start concurrently"
     >
       {consts.START_CONCURRNET_MARK}
     </button>

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -20,6 +20,7 @@ const StopButton = ({
     <button
       className="btn-icon"
       aria-label="Stop."
+      title="Stop."
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Done"
+      title="Done"
     >
       {consts.DONE_MARK}
     </button>

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Delete"
+      title="Delete"
     >
       {consts.DONT_MARK}
     </button>

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -16,6 +16,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}
+      aria-label="Top"
+      title="Top"
     >
       {consts.TOP_MARK}
     </button>


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to numerous icon-only buttons throughout the application, including:
- `StartButton`
- `StartConcurrentButton`
- `StopButton`
- `AddButton`
- `MoveUpButton` and `MoveDownButton` in `EntryButtons`
- `TopButton`
- `CopyNodeIdButton`
- `DoneOrDontToTodoButton`
- `EvalButton`
- `TodoToDoneButton`
- `TodoToDontButton`

### 🎯 Why
Icon-only buttons rely entirely on visual cues (like an arrow or a play icon). Without descriptive labels, users relying on screen readers encounter these buttons with no context about their function. Furthermore, users interacting with a mouse benefit from tooltips on hover to confirm the button's intended action. This small UX enhancement makes the application significantly more inclusive and user-friendly.

### 📸 Before/After
- **Before:** `<button className="btn-icon">{consts.START_MARK}</button>`
- **After:** `<button className="btn-icon" aria-label="Start" title="Start">{consts.START_MARK}</button>`

### ♿ Accessibility
This change dramatically improves the accessibility score and compliance of the main UI interface. Screen readers will now announce "Start", "Copy node id", etc., instead of unlabelled "button". Keyboard and mouse users can also trigger native OS-level tooltips via the `title` attribute for immediate feedback.

---
*PR created automatically by Jules for task [3271432383766578654](https://jules.google.com/task/3271432383766578654) started by @kshramt*