### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-03 - Added Security Headers via SetResponseHeaderLayer
+**Vulnerability:** The `api_v2` Axum application was missing basic security headers like `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, and `Referrer-Policy`. This could leave the application vulnerable to various attacks like clickjacking and MIME-sniffing.
+**Learning:** `tower-http`'s `SetResponseHeaderLayer::overriding()` is an effective way to inject headers globally. In `axum` with `hyper`, it's critical to use `hyper::header::HeaderValue::from_static` and `hyper::header::HeaderName::from_static` for custom or constant header definitions instead of relying solely on `http` crate components, which may not be linked natively by default in the workspace config.
+**Prevention:** Include a `SetResponseHeaderLayer` chain to enforce these security properties on newly created Axum routers by default.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,27 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("x-xss-protection"),
+            hyper::header::HeaderValue::from_static("1; mode=block"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("strict-origin-when-cross-origin"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
- 🚨 **Severity**: MEDIUM
- 💡 **Vulnerability**: The backend API `api_v2` was not serving standard HTTP security headers such as `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, and `Referrer-Policy`. This could lead to a variety of attacks including clickjacking, MIME-sniffing, and potential downgrade attacks.
- 🎯 **Impact**: Without these headers, clients are susceptible to cross-site scripting (via sniffed content types) and clickjacking if the API were to serve HTML. It is an industry standard to set these defense-in-depth protections.
- 🔧 **Fix**: Implemented `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs` to override and inject the required security headers into every response using `hyper::header`.
- ✅ **Verification**: Run `cd api_v2 && cargo test`. Tests will verify compilation. During execution, headers can be inspected using `curl -I`.

---
*PR created automatically by Jules for task [9452064791255383451](https://jules.google.com/task/9452064791255383451) started by @kshramt*