### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Missing Security Headers in Backend
+**Vulnerability:** The backend Axum server in `api_v2/src/main.rs` does not include basic security headers like `X-Content-Type-Options`, `X-Frame-Options`, and `Strict-Transport-Security`. While the Nginx proxy includes a `Content-Security-Policy`, relying solely on the proxy can lead to vulnerabilities if the proxy configuration is bypassed or misconfigured.
+**Learning:** Security headers should be configured directly within the backend service, providing a defense-in-depth approach.
+**Prevention:** Always verify that fundamental security headers are included in HTTP responses using middleware (e.g., `tower-http`'s `SetResponseHeaderLayer`) when setting up web servers.

--- a/api_v2/Cargo.toml
+++ b/api_v2/Cargo.toml
@@ -19,6 +19,6 @@ serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "macros", "uuid", "chrono", "json"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["full"] }
+tower-http = { version = "0.6", features = ["full", "set-header"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -389,6 +390,18 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
* 🚨 Severity: MEDIUM
* 💡 Vulnerability: Missing security headers on backend endpoints.
* 🎯 Impact: Without `X-Content-Type-Options: nosniff`, browsers might interpret files as a different MIME type, leading to XSS. Without `X-Frame-Options: DENY`, the app might be embedded in an iframe on an attacker's site, leading to clickjacking. Without `Strict-Transport-Security`, browsers might use plain HTTP for initial requests.
* 🔧 Fix: Added `tower_http::set_header::SetResponseHeaderLayer` middleware to `api_v2/src/main.rs` to enforce `X-Content-Type-Options`, `X-Frame-Options`, and `Strict-Transport-Security`. Required enabling the `set-header` feature in `tower-http` within `api_v2/Cargo.toml`.
* ✅ Verification: Tested successfully with `cargo check` and `cargo test`.

---
*PR created automatically by Jules for task [12421515670186875228](https://jules.google.com/task/12421515670186875228) started by @kshramt*