### PR TITLE
🎨 Palette: [UX improvement] Add accessible labels and tooltips to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-16 - Add accessible labels and tooltips to icon-only buttons
+**Learning:** Icon-only buttons relying on constants for icons (`START_MARK`, `ADD_MARK`, etc.) without text content lack accessibility contexts and native hover tooltips unless `aria-label` and `title` are specifically provided on the wrapping component. Additionally, dynamic properties within these attributes (like `is_copied` state) need to evaluate strictly to strings to avoid `[object Object]` rendering bugs in the DOM when complex nodes are passed.
+**Action:** When creating new icon-only buttons or wrapping existing ones, explicitly add both `aria-label` and `title` properties. Verify that dynamically generated labels evaluate cleanly to strings before assigning them to these properties.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label={is_copied ? "Copied" : "Copy node ID"}
+      title={is_copied ? "Copied" : "Copy node ID"}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Revert to todo"
+      title="Revert to todo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -15,6 +15,8 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Evaluate"
+      title="Evaluate"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      aria-label="Stop"
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
+      title="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as won't do"
+      title="Mark as won't do"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to top"
+      title="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to numerous icon-only buttons across the frontend components (`AddButton`, `StartButton`, `StopButton`, `CopyNodeIdButton`, `EvalButton`, `TodoToDoneButton`, etc.). For dynamic states, like `CopyNodeIdButton`, the labels contextually reflect the current state (e.g., "Copied" vs "Copy node ID").

🎯 **Why:** Icon-only buttons lacking accessible labels fail to provide context to screen readers, and lacking tooltips, they fail to provide hover context for mouse users unfamiliar with the specific iconography. This creates a significant usability barrier.

📸 **Before/After:**
*   **Before:** `<button className="btn-icon">{consts.ADD_MARK}</button>`
*   **After:** `<button className="btn-icon" aria-label="Add" title="Add">{consts.ADD_MARK}</button>`

♿ **Accessibility:**
*   Added `aria-label` directly to `<button>` elements to properly surface the button's intent to screen readers natively.
*   Added `title` to provide native browser tooltips for visual mouse users, clarifying the icon's action.
*   Ensured dynamic properties passed to these attributes evaluate cleanly as strings.

---
*PR created automatically by Jules for task [1133398806034442266](https://jules.google.com/task/1133398806034442266) started by @kshramt*