### PR TITLE
⚡ Bolt: Add React.memo to QueueEntry to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-04 - Virtualized List Item Memoization
+**Learning:** `QueueEntry` inside `react-virtuoso` was unmemoized, leading to O(N) re-renders for every status update or scroll event since its props (`node_id`, `index`) are primitives.
+**Action:** Always wrap leaf list components inside virtualized or mapped lists with `React.memo` when props are primitive, and append `displayName` to preserve DevTools readability.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders during scrolling and state updates within react-virtuoso virtualized lists
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 **What:** Wrapped the `QueueEntry` component in `client/src/QueueEntry.tsx` with `React.memo()`. Also added `QueueEntry.displayName` to ensure it is cleanly identifiable in React DevTools.
🎯 **Why:** `QueueEntry` is rendered heavily inside a `react-virtuoso` virtualized list. Without `React.memo()`, every state update or scroll event in the parent can trigger O(N) re-renders of the list items, even though their props (`node_id`, `index`) are just primitives and haven't actually changed.
📊 **Impact:** Significantly reduces the number of unnecessary component re-renders during virtualized list scrolling and unrelated application state updates. Performance boost scales linearly with the number of visible items on screen.
🔬 **Measurement:** Use React DevTools Profiler while scrolling through the main queue or marking items as done. You should observe that `QueueEntry` nodes now explicitly skip re-rendering if their specific `node_id` or `index` haven't changed.

---
*PR created automatically by Jules for task [11277785139434958852](https://jules.google.com/task/11277785139434958852) started by @kshramt*