### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-05 - Security Headers Implementation
+**Vulnerability:** The API lacked basic security headers, exposing users to a number of potential attacks such as MIME-sniffing, clickjacking, and XSS without standard browser-enforced mitigations.
+**Learning:** `tower_http::set_header::SetResponseHeaderLayer` acts as a builder in axum when chained; using `.layer` repeatedly allows setting multiple distinct headers safely. If the header key is non-standard, use `HeaderName::from_static("...");`.
+**Prevention:** Consider creating an isolated configuration builder module for response headers so they are added to all current and future endpoints uniformly.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,7 +391,27 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::HeaderName::from_static("referrer-policy"),
+            hyper::header::HeaderValue::from_static("strict-origin-when-cross-origin"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'self'"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The API backend lacked crucial HTTP response headers, leaving clients open to clickjacking, MIME-sniffing, and potential downgrade attacks.
🎯 Impact: Without these headers, malicious sites could embed the application via iframes, or browsers might incorrectly guess content types and execute malicious scripts.
🔧 Fix: Configured `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs` to enforce `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Strict-Transport-Security`, `Referrer-Policy: strict-origin-when-cross-origin`, and `Content-Security-Policy: default-src 'self'`.
✅ Verification: Start the backend via `cargo run` and execute `curl -I localhost:8080` (or the configured port) to ensure all five headers are correctly returned.

---
*PR created automatically by Jules for task [2933561304459389369](https://jules.google.com/task/2933561304459389369) started by @kshramt*