### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-07 - Tower HTTP Security Headers
+**Vulnerability:** Missing important security headers like Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, and Strict-Transport-Security in Axum server.
+**Learning:** Adding Axum server headers using `tower_http` is done with `SetResponseHeaderLayer::overriding`. It requires `hyper::header` definitions instead of `http::header`. Additionally, Axum projects with auto-generated modules (like `gen.rs`) may cause `dead_code` warnings. To fix this, apply `#[allow(dead_code)]` only on the specific module (`mod gen;`) instead of globally suppressing warnings using `#![allow(dead_code)]`.
+**Prevention:** Ensure security header implementations are paired with targeted module-level lint configurations rather than global crate-level suppressions.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,6 +391,22 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 
     let port = get_server_port();


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Axum backend application lacked standard HTTP security headers (Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, Strict-Transport-Security), leaving the application susceptible to cross-site scripting (XSS), MIME-sniffing, clickjacking, and man-in-the-middle attacks.
🎯 Impact: Without these headers, browsers lack the directives to strictly enforce security policies. This increases the overall attack surface and vulnerability risk for end-users interacting with the API or a frontend application built on it.
🔧 Fix: Configured `tower_http::set_header::SetResponseHeaderLayer` in the main Axum application router (`api_v2/src/main.rs`) to inject the missing security headers with secure default values. Additionally, added a localized `#[allow(dead_code)]` to the auto-generated `gen` module to address linter warnings without suppressing global warnings.
✅ Verification: Ran `cargo test`, `cargo clippy`, and verified via `git diff` that the correct security layers are now chaining on the application router before deployment.

---
*PR created automatically by Jules for task [12845662874032187944](https://jules.google.com/task/12845662874032187944) started by @kshramt*