### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+## 2026-06-07 - Added tooltips and ARIA labels to icon-only buttons\n**Learning:** Added accessibility traits (aria-label) and native tooltips (title) to the icon-only `<button>` components within the client.\n**Action:** When creating custom icon-only components, ensure that `aria-label` and `title` are explicitly exposed and populated.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,8 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add"
+      title="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move up"
+      title="Move up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +79,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move down"
+      title="Move down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to `StartButton`, `StartConcurrentButton`, `AddButton`, `MoveUpButton`, and `MoveDownButton`.
🎯 Why: Icon-only buttons without accessible names are invisible to screen readers, and lack tooltips for sighted users. This change improves both a11y and general UX.
📸 Before/After: Before, buttons had no native tooltip on hover. Now, hovering displays a tooltip like "Start" or "Move up", and screen readers can announce the action.
♿ Accessibility: Improved screen reader compatibility by giving standard icon-only `<button>`s an explicit name.

---
*PR created automatically by Jules for task [8476410258883981869](https://jules.google.com/task/8476410258883981869) started by @kshramt*