### PR TITLE
🎨 Palette: Add accessibility attributes to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-08 - Icon-only buttons require explicit accessible names
+**Learning:** React components acting as icon-only buttons (using `btn-icon`) must explicitly include `aria-label` and `title` attributes. Without these, the buttons are functionally invisible to screen readers, and lack tooltip affordances for pointer users.
+**Action:** Always verify that components rendering an icon-only `<button>` without visible text receive `aria-label` (for a11y) and `title` (for mouse users). This applies to custom components like `AddButton`, `StartButton`, and inline `<button>` definitions within lists.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move up"
+      title="Move up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +79,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move down"
+      title="Move down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
## What
Added `aria-label` and `title` attributes to several core icon-only action buttons: `AddButton`, `StartButton`, `StartConcurrentButton`, `MoveUpButton`, and `MoveDownButton`.

## Why
These buttons previously only rendered an icon with no text content, making them completely inaccessible to screen reader users (who would just hear "button" with no context). Adding these attributes also improves usability for mouse users by providing helpful tooltips on hover.

## Before/After
**Before:** `<button className="btn-icon">{icon}</button>`
**After:** `<button className="btn-icon" aria-label="Add" title="Add">{icon}</button>`

## Accessibility
Significantly improves screen reader navigation by ensuring these primary action buttons have proper accessible names. Complies with WCAG 4.1.2 Name, Role, Value.

---
*PR created automatically by Jules for task [9185895659448385983](https://jules.google.com/task/9185895659448385983) started by @kshramt*