### PR TITLE
🎨 Palette: Add accessibility tooltips to CopyNodeIdButton

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-25 - CopyNodeIdButton Accessibility Fix
+**Learning:** Icon-only buttons mapping to generic components like `CopyNodeIdButton` often miss explicit tooltips and ARIA labels. We need to implement dynamic labeling when states change (e.g., from "Copy" to "Copied") to ensure users get immediate screen reader and visual feedback.
+**Action:** Always check interactive components containing solely constant icon markers (`consts.COPY_MARK`, etc.) to ensure they have an `aria-label` or `title` mapped to their state.

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label={is_copied ? "Copied ID" : "Copy ID"}
+      title={is_copied ? "Copied ID" : "Copy ID"}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
**What**: Added dynamic `aria-label` and `title` attributes to `CopyNodeIdButton` that toggle based on the `is_copied` state.
**Why**: The `CopyNodeIdButton` was an icon-only button without any label. Screen reader users would hear "button" without context, and mouse users lacked a tooltip to explain the icon's action or status upon clicking.
**Before/After**: Before, it was just `<button className="btn-icon">`. Now it behaves dynamically, giving the user either "Copy ID" or "Copied ID" depending on interaction.
**Accessibility**: Improves screen reader accessibility via descriptive `aria-label` and general usability with standard native `title` tooltips.

---
*PR created automatically by Jules for task [6389451373561505044](https://jules.google.com/task/6389451373561505044) started by @kshramt*