### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-10 - Missing React.memo for Virtualized List Components
+**Learning:** Components rendered within `react-virtuoso` lists (like `QueueEntry`, `MobileQueueNode`, `TreeEntry`, `EdgeRow`) receive primitive props but are not wrapped in `React.memo`. This causes unnecessary O(N) re-renders during state updates and scrolling.
+**Action:** When working on large virtualized or mapped lists in React, wrap the entry components in `React.memo` and set their `displayName`.

--- a/client/src/EdgeRow/index.tsx
+++ b/client/src/EdgeRow/index.tsx
@@ -7,7 +7,7 @@ import * as toast from "src/toast";
 import * as types from "src/types";
 import * as utils from "src/utils";
 
-const EdgeRow = (props: { edge_id: types.TEdgeId; target: "p" | "c" }) => {
+const EdgeRowImpl = (props: { edge_id: types.TEdgeId; target: "p" | "c" }) => {
   // const edge = types.useSelector((state) => state.data.edges[props.edge_id]);
   const edgeT = utils.assertV(
     types.useSelector((state) => state.swapped_edges.t?.[props.edge_id]),
@@ -105,4 +105,7 @@ const EdgeRowContent = (props: { node_id: types.TNodeId }) => {
   );
 };
 
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders during scrolling and state updates in virtualized lists.
+const EdgeRow = React.memo(EdgeRowImpl);
+EdgeRow.displayName = "EdgeRow";
 export default EdgeRow;

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,10 +17,7 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
+const QueueEntryImpl = (props: { node_id: types.TNodeId; index: number }) => {
   const exists = useRawSelector((state) =>
     Object.hasOwn(state.data.nodes, props.node_id),
   );
@@ -30,6 +27,10 @@ export const QueueEntry = (props: {
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
 };
+
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders during scrolling and state updates in virtualized lists.
+export const QueueEntry = React.memo(QueueEntryImpl);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,7 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+const MobileQueueNodeImpl = (props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1237,7 +1237,11 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
   );
 };
 
-const TreeEntry = (props: {
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders during scrolling and state updates in virtualized lists.
+const MobileQueueNode = React.memo(MobileQueueNodeImpl);
+MobileQueueNode.displayName = "MobileQueueNode";
+
+const TreeEntryImpl = (props: {
   node_id: types.TNodeId;
   prefix?: undefined | string;
 }) => {
@@ -1293,6 +1297,10 @@ const TreeEntry = (props: {
     </EntryWrapper>
   );
 };
+
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders during scrolling and state updates in virtualized lists.
+const TreeEntry = React.memo(TreeEntryImpl);
+TreeEntry.displayName = "TreeEntry";
 
 const MobileEntryButtons = (props: { node_id: types.TNodeId }) => {
   const leaf_estimates_sum = utils.assertV(


### PR DESCRIPTION
💡 What: Wrapped list item components in `React.memo` (`QueueEntry`, `MobileQueueNode`, `TreeEntry`, and `EdgeRow`). Set their `displayName`s to maintain DevTools support.
🎯 Why: Unnecessary re-renders were occurring during scrolling and state updates in `react-virtuoso` and mapped array lists because the underlying components weren't memoized.
📊 Impact: Significantly reduces O(N) re-renders in virtualized/mapped arrays when global state changes or the user scrolls.
🔬 Measurement: Observe React DevTools Profiler to verify `QueueEntry`, `MobileQueueNode`, `TreeEntry`, and `EdgeRow` do not re-render unless their specific primitive props change.

---
*PR created automatically by Jules for task [2192023464282999927](https://jules.google.com/task/2192023464282999927) started by @kshramt*