### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-12-07 - Accessible Icon Buttons
+**Learning:** Found multiple icon-only buttons across the application (like AddButton, StartButton, StopButton) that lacked `aria-label`s for screen readers and `title` attributes for native browser tooltips.
+**Action:** Always ensure icon-only buttons have descriptive `aria-label` and `title` attributes implemented to improve both accessibility and general usability.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add new entry"
+      title="Add new entry"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -20,6 +20,7 @@ const StopButton = ({
     <button
       className="btn-icon"
       aria-label="Stop."
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Mark as done"
+      title="Mark as done"
     >
       {consts.DONE_MARK}
     </button>

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Delete"
+      title="Delete"
     >
       {consts.DONT_MARK}
     </button>


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to several icon-only action buttons across the application (Add, Start, Stop, Done, Delete).

### 🎯 Why
Icon-only buttons without accessible labels are invisible to screen readers, making the application difficult or impossible to navigate for users with visual impairments. Furthermore, sighted users also benefit from tooltips (`title` attribute) to clarify the action of an icon, especially if they are new to the interface.

### 📸 Before/After
**Before:** Buttons only contained a Material Icon.
**After:** Buttons now include descriptive text for both screen readers and hover tooltips.

### ♿ Accessibility
This change ensures that all primary action buttons are fully accessible via keyboard and screen reader, providing clear context for every action.

---
*PR created automatically by Jules for task [13297388791925237814](https://jules.google.com/task/13297388791925237814) started by @kshramt*