### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Authorization status codes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-12 - Improper HTTP Error Status Codes for Authorization
+**Vulnerability:** The application's authentication and authorization handlers returned a generic `400 Bad Request` (`ErrorStatus::Status400`) instead of semantic HTTP error status codes like `401 Unauthorized` or `403 Forbidden`.
+**Learning:** Returning a generic `400 Bad Request` can obscure authentication or authorization failures from clients and API consumers. This makes it difficult to differentiate client input errors from actual access control violations in monitoring systems, potentially hampering intrusion detection mechanisms.
+**Prevention:** Ensure custom error mapping layers translate authentication missing/invalid errors to `401 Unauthorized` and failed permission checks to `403 Forbidden` explicitly.

--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -7,8 +7,11 @@ use serde_json::json;
 use tracing::error;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum ErrorStatus {
     Status400,
+    Status401,
+    Status403,
     Status500,
 }
 
@@ -18,6 +21,8 @@ impl std::fmt::Display for ErrorStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ErrorStatus::Status400 => write!(f, "Status400"),
+            ErrorStatus::Status401 => write!(f, "Status401"),
+            ErrorStatus::Status403 => write!(f, "Status403"),
             ErrorStatus::Status500 => write!(f, "Status500"),
         }
     }
@@ -45,6 +50,14 @@ impl IntoResponse for ErrorStatus {
                 Json(json!({"error": "Bad request."})),
             )
                 .into_response(),
+            ErrorStatus::Status401 => (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "Unauthorized."})),
+            )
+                .into_response(),
+            ErrorStatus::Status403 => {
+                (StatusCode::FORBIDDEN, Json(json!({"error": "Forbidden."}))).into_response()
+            }
             ErrorStatus::Status500 => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "Something went wrong."})),

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -36,7 +37,7 @@ where
         let TypedHeader(Authorization(bearer)) = parts
             .extract::<TypedHeader<Authorization<Bearer>>>()
             .await
-            .map_err(|_| errors::ErrorStatus::Status400)?;
+            .map_err(|_| errors::ErrorStatus::Status401)?;
         Self::from_base64(bearer.token())
     }
 }
@@ -45,15 +46,15 @@ impl gen::IdToken {
     pub fn from_base64(s: &str) -> Result<Self, errors::ErrorStatus> {
         let s = base64::engine::general_purpose::STANDARD
             .decode(s)
-            .map_err(|_| errors::ErrorStatus::Status400)?;
-        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status400)
+            .map_err(|_| errors::ErrorStatus::Status401)?;
+        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status401)
     }
 
     pub fn authorize(&self, user_id: &str) -> Result<(), errors::ErrorStatus> {
         if self.user_id == user_id {
             Ok(())
         } else {
-            Err(errors::ErrorStatus::Status400)
+            Err(errors::ErrorStatus::Status403)
         }
     }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The API returned a generic `400 Bad Request` status code for both invalid tokens and failed authorization checks, obscuring the root cause and potentially interfering with automated abuse detection.
🎯 Impact: Obscuring authentication failures can make it harder for infrastructure (WAFs, logging, etc.) to detect credential stuffing or unauthorized access attempts.
🔧 Fix: Added `Status401` and `Status403` to `ErrorStatus` and mapped them to `StatusCode::UNAUTHORIZED` and `StatusCode::FORBIDDEN`. Updated the token parsing to return 401 and the authorization check to return 403.
✅ Verification: Ensure tests pass locally by running `cd api_v2 && cargo check && cargo test`.

---
*PR created automatically by Jules for task [10607847630295496854](https://jules.google.com/task/10607847630295496854) started by @kshramt*