### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-12 - Ensure aria-labels for buttons
+**Learning:** React elements rendering material icons directly lack screen-reader context if no aria-label is provided to the wrapper button.
+**Action:** Add aria-label attributes to icon-only buttons for accessibility.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,7 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,7 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Copy node ID"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -109,6 +109,7 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Show details"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,7 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,7 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as don't"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,7 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}


### PR DESCRIPTION
- 💡 What: Added `aria-label` attributes to various icon-only buttons (`StartButton`, `AddButton`, etc.).
- 🎯 Why: Screen readers cannot announce the purpose of buttons that only contain Material Icons without an `aria-label`, making them inaccessible.
- 📸 Before/After: Buttons previously had no screen reader context; now they have descriptive labels like "Start", "Add", etc.
- ♿ Accessibility: Improved screen reader navigation and context for core interactive elements.

---
*PR created automatically by Jules for task [11162572485929082043](https://jules.google.com/task/11162572485929082043) started by @kshramt*