### PR TITLE
🛡️ Sentinel: [security improvement] Accurate HTTP Status Codes for Auth Failures

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-26 - Accurate HTTP Status Codes for Auth Failures
+**Vulnerability:** Inaccurate HTTP status codes for authentication/authorization failures.
+**Learning:** The application was returning a generic 400 Bad Request for invalid tokens and missing permissions. This obscures the nature of the security failure from clients and monitoring systems, making it difficult to detect brute-force token guessing or privilege escalation attempts.
+**Prevention:** Always distinguish between 401 Unauthorized (unauthenticated/invalid token) and 403 Forbidden (authenticated but lacking permissions) instead of falling back to generic 400 errors.

--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -9,6 +9,8 @@ use tracing::error;
 #[derive(Debug)]
 pub enum ErrorStatus {
     Status400,
+    Status401,
+    Status403,
     Status500,
 }
 
@@ -18,6 +20,8 @@ impl std::fmt::Display for ErrorStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ErrorStatus::Status400 => write!(f, "Status400"),
+            ErrorStatus::Status401 => write!(f, "Status401"),
+            ErrorStatus::Status403 => write!(f, "Status403"),
             ErrorStatus::Status500 => write!(f, "Status500"),
         }
     }
@@ -43,6 +47,16 @@ impl IntoResponse for ErrorStatus {
             ErrorStatus::Status400 => (
                 StatusCode::BAD_REQUEST,
                 Json(json!({"error": "Bad request."})),
+            )
+                .into_response(),
+            ErrorStatus::Status401 => (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "Unauthorized."})),
+            )
+                .into_response(),
+            ErrorStatus::Status403 => (
+                StatusCode::FORBIDDEN,
+                Json(json!({"error": "Forbidden."})),
             )
                 .into_response(),
             ErrorStatus::Status500 => (

--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -54,11 +54,9 @@ impl IntoResponse for ErrorStatus {
                 Json(json!({"error": "Unauthorized."})),
             )
                 .into_response(),
-            ErrorStatus::Status403 => (
-                StatusCode::FORBIDDEN,
-                Json(json!({"error": "Forbidden."})),
-            )
-                .into_response(),
+            ErrorStatus::Status403 => {
+                (StatusCode::FORBIDDEN, Json(json!({"error": "Forbidden."}))).into_response()
+            }
             ErrorStatus::Status500 => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "Something went wrong."})),

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -36,7 +36,7 @@ where
         let TypedHeader(Authorization(bearer)) = parts
             .extract::<TypedHeader<Authorization<Bearer>>>()
             .await
-            .map_err(|_| errors::ErrorStatus::Status400)?;
+            .map_err(|_| errors::ErrorStatus::Status401)?;
         Self::from_base64(bearer.token())
     }
 }
@@ -45,15 +45,15 @@ impl gen::IdToken {
     pub fn from_base64(s: &str) -> Result<Self, errors::ErrorStatus> {
         let s = base64::engine::general_purpose::STANDARD
             .decode(s)
-            .map_err(|_| errors::ErrorStatus::Status400)?;
-        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status400)
+            .map_err(|_| errors::ErrorStatus::Status401)?;
+        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status401)
     }
 
     pub fn authorize(&self, user_id: &str) -> Result<(), errors::ErrorStatus> {
         if self.user_id == user_id {
             Ok(())
         } else {
-            Err(errors::ErrorStatus::Status400)
+            Err(errors::ErrorStatus::Status403)
         }
     }
 }


### PR DESCRIPTION
🚨 **Severity:** LOW/MEDIUM (Security Enhancement)
💡 **Vulnerability:** The API was previously returning generic `400 Bad Request` status codes for authentication (missing/invalid token) and authorization (missing permissions) failures. This practice obscures security-relevant events from clients, observability tools, and WAFs, making it difficult to differentiate between malformed requests and potential malicious activity (e.g., credential stuffing, unauthorized access attempts).
🎯 **Impact:** Accurate status codes (`401` and `403`) significantly improve security monitoring, allowing for proper alerting on sustained authorization/authentication failures. It also aligns the API with REST standards and improves the developer experience for clients integrating with the API.
🔧 **Fix:** 
- Added `Status401` and `Status403` to the `ErrorStatus` enum in `api_v2/src/errors.rs`.
- Implemented corresponding `StatusCode::UNAUTHORIZED` and `StatusCode::FORBIDDEN` mappings in the `IntoResponse` trait.
- Updated `gen::IdToken::from_request_parts` and `gen::IdToken::from_base64` to return `Status401` on parsing/extraction failure.
- Updated `gen::IdToken::authorize` to return `Status403` when the user ID doesn't match the token's user ID.
✅ **Verification:** Ran `cargo check`, `cargo test`, `cargo fmt`, and `cargo clippy` in `api_v2` to verify backend changes. Ran `pnpm test` in the `client` directory to ensure frontend compatibility.

---
*PR created automatically by Jules for task [5920333415843400632](https://jules.google.com/task/5920333415843400632) started by @kshramt*