### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-14 - Improve Icon Button Accessibility
+**Learning:** This app heavily relies on icon-only buttons for core features (e.g. Add, Start, Top, TodoToDone), but most lack `aria-label`s, causing screen readers to just read "button". Applying labels provides crucial accessibility context without altering visual design.
+**Action:** When adding or modifying icon-only buttons (`btn-icon`), always ensure they have a descriptive `aria-label` associated with them so assistive tech can understand their purpose.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,7 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,7 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Copy node ID"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,7 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,7 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}


### PR DESCRIPTION
* 💡 What: Added `aria-label` attributes to various icon-only buttons (`AddButton`, `StartButton`, `TopButton`, `CopyNodeIdButton`, `TodoToDoneButton`).
* 🎯 Why: Icon-only buttons without accessible names are announced simply as "button" by screen readers. Adding `aria-label`s makes their purpose clear to assistive technologies, improving usability.
* 📸 Before/After: Visuals are unchanged. Screen readers now announce actions like "Add", "Start", "Move to top" instead of "button".
* ♿ Accessibility: Enhances keyboard and screen reader accessibility by providing descriptive context to core interactive elements.

---
*PR created automatically by Jules for task [6921103584661712517](https://jules.google.com/task/6921103584661712517) started by @kshramt*