### PR TITLE
⚡ Bolt: [performance improvement] Memoize list components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-15 - Identify un-memoized list items
+**Learning:** Found components that receive primitive props (`node_id`, `index`, `nodeId`) and render inside a `.map` loop or `react-virtuoso` virtualized list but are not using `React.memo`. This causes unnecessary O(N) re-renders when list data changes or when scrolling.
+**Action:** Always check if list item components (`QueueEntry`, `MobileQueueNode`, `TreeEntry`, `EdgeRow`) are wrapped with `React.memo`. When adding `React.memo`, also append `.displayName` to retain readability in React DevTools.

--- a/client/src/EdgeRow/index.tsx
+++ b/client/src/EdgeRow/index.tsx
@@ -7,75 +7,79 @@ import * as toast from "src/toast";
 import * as types from "src/types";
 import * as utils from "src/utils";
 
-const EdgeRow = (props: { edge_id: types.TEdgeId; target: "p" | "c" }) => {
-  // const edge = types.useSelector((state) => state.data.edges[props.edge_id]);
-  const edgeT = utils.assertV(
-    types.useSelector((state) => state.swapped_edges.t?.[props.edge_id]),
-  );
-  const nodeId = utils.assertV(
-    types.useSelector(
-      (state) => state.swapped_edges[props.target]?.[props.edge_id],
-    ),
-  );
-  const edgeHide = types.useSelector(
-    (state) => state.swapped_edges.hide?.[props.edge_id],
-  );
-  const dispatch = types.useDispatch();
-  const delete_edge = React.useCallback(
-    () => dispatch(actions.delete_edge_action(props.edge_id)),
-    [props.edge_id, dispatch],
-  );
-  const set_edge_type = React.useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const edge_type = e.target.value;
-      if (types.is_TEdgeType(edge_type)) {
-        dispatch(
-          actions.set_edge_type_action({
-            edge_id: props.edge_id,
-            edge_type,
-          }),
-        );
-      } else {
-        toast.add("error", `Invalid edge type: ${edge_type}`);
-      }
-    },
-    [props.edge_id, dispatch],
-  );
-  const toggle_edge_hide = React.useCallback(() => {
-    dispatch(actions.toggle_edge_hide_action(props.edge_id));
-  }, [props.edge_id, dispatch]);
-  return (
-    <tr>
-      <EdgeRowContent node_id={nodeId} />
-      <td className="p-[0.25em]">
-        <select value={edgeT} onChange={set_edge_type}>
-          {types.edgeTypeValues.map((t, i) => (
-            <option value={t} key={i}>
-              {t}
-            </option>
-          ))}
-        </select>
-      </td>
-      <td className="p-[0.25em]">
-        <input
-          type="radio"
-          checked={!edgeHide}
-          onClick={toggle_edge_hide}
-          onChange={utils.suppress_missing_onChange_handler_warning}
-        />
-      </td>
-      <td className="p-[0.25em]">
-        <button
-          className="btn-icon"
-          onClick={delete_edge}
-          onDoubleClick={utils.prevent_propagation}
-        >
-          {consts.DELETE_MARK}
-        </button>
-      </td>
-    </tr>
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders during state updates within mapped arrays.
+const EdgeRow = React.memo(
+  (props: { edge_id: types.TEdgeId; target: "p" | "c" }) => {
+    // const edge = types.useSelector((state) => state.data.edges[props.edge_id]);
+    const edgeT = utils.assertV(
+      types.useSelector((state) => state.swapped_edges.t?.[props.edge_id]),
+    );
+    const nodeId = utils.assertV(
+      types.useSelector(
+        (state) => state.swapped_edges[props.target]?.[props.edge_id],
+      ),
+    );
+    const edgeHide = types.useSelector(
+      (state) => state.swapped_edges.hide?.[props.edge_id],
+    );
+    const dispatch = types.useDispatch();
+    const delete_edge = React.useCallback(
+      () => dispatch(actions.delete_edge_action(props.edge_id)),
+      [props.edge_id, dispatch],
+    );
+    const set_edge_type = React.useCallback(
+      (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const edge_type = e.target.value;
+        if (types.is_TEdgeType(edge_type)) {
+          dispatch(
+            actions.set_edge_type_action({
+              edge_id: props.edge_id,
+              edge_type,
+            }),
+          );
+        } else {
+          toast.add("error", `Invalid edge type: ${edge_type}`);
+        }
+      },
+      [props.edge_id, dispatch],
+    );
+    const toggle_edge_hide = React.useCallback(() => {
+      dispatch(actions.toggle_edge_hide_action(props.edge_id));
+    }, [props.edge_id, dispatch]);
+    return (
+      <tr>
+        <EdgeRowContent node_id={nodeId} />
+        <td className="p-[0.25em]">
+          <select value={edgeT} onChange={set_edge_type}>
+            {types.edgeTypeValues.map((t, i) => (
+              <option value={t} key={i}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </td>
+        <td className="p-[0.25em]">
+          <input
+            type="radio"
+            checked={!edgeHide}
+            onClick={toggle_edge_hide}
+            onChange={utils.suppress_missing_onChange_handler_warning}
+          />
+        </td>
+        <td className="p-[0.25em]">
+          <button
+            className="btn-icon"
+            onClick={delete_edge}
+            onDoubleClick={utils.prevent_propagation}
+          >
+            {consts.DELETE_MARK}
+          </button>
+        </td>
+      </tr>
+    );
+  },
+);
+EdgeRow.displayName = "EdgeRow";
 
 const EdgeRowContent = (props: { node_id: types.TNodeId }) => {
   const to_tree = utils.useToTree(props.node_id);

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders during scrolling and state updates within react-virtuoso virtualized lists or mapped arrays.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -1225,7 +1225,8 @@ const MobileQueueNodesImpl = (props: { node_ids: types.TNodeId[] }) => {
     </>
   );
 };
-const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders during scrolling and state updates.
+const MobileQueueNode = React.memo((props: { nodeId: types.TNodeId }) => {
   return (
     <EntryWrapper node_id={props.nodeId}>
       <TextArea
@@ -1235,64 +1236,66 @@ const MobileQueueNode = (props: { nodeId: types.TNodeId }) => {
       <MobileEntryButtons node_id={props.nodeId} />
     </EntryWrapper>
   );
-};
+});
+MobileQueueNode.displayName = "MobileQueueNode";
 
-const TreeEntry = (props: {
-  node_id: types.TNodeId;
-  prefix?: undefined | string;
-}) => {
-  const leaf_estimates_sum = utils.assertV(
-    useSelector(
-      (state) => state.swapped_caches.leaf_estimates_sum?.[props.node_id],
-    ),
-  );
-  const percentiles = utils.assertV(
-    useSelector((state) => state.swapped_caches.percentiles?.[props.node_id]),
-  );
-  const status = utils.assertV(
-    useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
-  );
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders during state updates within mapped arrays.
+const TreeEntry = React.memo(
+  (props: { node_id: types.TNodeId; prefix?: undefined | string }) => {
+    const leaf_estimates_sum = utils.assertV(
+      useSelector(
+        (state) => state.swapped_caches.leaf_estimates_sum?.[props.node_id],
+      ),
+    );
+    const percentiles = utils.assertV(
+      useSelector((state) => state.swapped_caches.percentiles?.[props.node_id]),
+    );
+    const status = utils.assertV(
+      useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
+    );
 
-  const to_queue = useToQueue(props.node_id);
-  const root = useSelector((state) => state.data.root);
-  const is_root = props.node_id === root;
-  const prefix = props.prefix || consts.TREE_PREFIX;
-  const handleKeyDown = hooks.useTaskShortcutKeys(props.node_id, prefix);
+    const to_queue = useToQueue(props.node_id);
+    const root = useSelector((state) => state.data.root);
+    const is_root = props.node_id === root;
+    const prefix = props.prefix || consts.TREE_PREFIX;
+    const handleKeyDown = hooks.useTaskShortcutKeys(props.node_id, prefix);
 
-  return (
-    <EntryWrapper node_id={props.node_id}>
-      <div className="flex items-end w-fit content-visibility-auto">
+    return (
+      <EntryWrapper node_id={props.node_id}>
+        <div className="flex items-end w-fit content-visibility-auto">
+          {is_root ? null : (
+            <TextArea
+              node_id={props.node_id}
+              id={`${prefix}${props.node_id}`}
+              className={utils.join(
+                "w-[29em] px-[0.75em] py-[0.5em]",
+                status === "done"
+                  ? "text-red-600 dark:text-red-400"
+                  : status === "dont"
+                    ? "text-neutral-500"
+                    : null,
+              )}
+              onKeyDown={handleKeyDown}
+            />
+          )}
+          <EntryInfos node_id={props.node_id} />
+        </div>
+        {status === "todo" &&
+          0 <= leaf_estimates_sum &&
+          utils.digits1(leaf_estimates_sum) + " | "}
+        {status === "todo" && percentiles.map(utils.digits1).join(", ")}
         {is_root ? null : (
-          <TextArea
+          <EntryButtons
             node_id={props.node_id}
-            id={`${prefix}${props.node_id}`}
-            className={utils.join(
-              "w-[29em] px-[0.75em] py-[0.5em]",
-              status === "done"
-                ? "text-red-600 dark:text-red-400"
-                : status === "dont"
-                  ? "text-neutral-500"
-                  : null,
-            )}
-            onKeyDown={handleKeyDown}
+            jumpButton={is_root ? null : <button onClick={to_queue}>→</button>}
+            prefix={prefix}
           />
         )}
-        <EntryInfos node_id={props.node_id} />
-      </div>
-      {status === "todo" &&
-        0 <= leaf_estimates_sum &&
-        utils.digits1(leaf_estimates_sum) + " | "}
-      {status === "todo" && percentiles.map(utils.digits1).join(", ")}
-      {is_root ? null : (
-        <EntryButtons
-          node_id={props.node_id}
-          jumpButton={is_root ? null : <button onClick={to_queue}>→</button>}
-          prefix={prefix}
-        />
-      )}
-    </EntryWrapper>
-  );
-};
+      </EntryWrapper>
+    );
+  },
+);
+TreeEntry.displayName = "TreeEntry";
 
 const MobileEntryButtons = (props: { node_id: types.TNodeId }) => {
   const leaf_estimates_sum = utils.assertV(


### PR DESCRIPTION
💡 What: Added `React.memo` to `QueueEntry`, `MobileQueueNode`, `TreeEntry`, and `EdgeRow`.
🎯 Why: These list items receive primitive props (`node_id`, `index`) and render inside arrays or virtualized lists. When un-memoized, they cause unnecessary O(N) re-renders.
📊 Impact: Prevents unnecessary O(N) re-renders during scrolling and state updates.
🔬 Measurement: Verify using React DevTools Profiler by toggling state and observing skipped re-renders for list items.

---
*PR created automatically by Jules for task [16536929353309361873](https://jules.google.com/task/16536929353309361873) started by @kshramt*