### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and tooltips to icon-only buttons

### DIFF
--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label={is_copied ? "Copied" : "Copy Node ID"}
+      title={is_copied ? "Copied" : "Copy Node ID"}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to top"
+      title="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}


### PR DESCRIPTION
* 💡 **What**: Added `aria-label` and `title` to `StartButton`, `TopButton`, and `CopyNodeIdButton`.
* 🎯 **Why**: These icon-only buttons lacked tooltip hover states and screen reader descriptions, making them difficult to understand.
* 📸 **Before/After**: Hovering over the buttons now displays a helpful tooltip (e.g., "Copy Node ID", "Start"). Screen readers will now announce them correctly.
* ♿ **Accessibility**: Improved screen reader support and general usability by explicitly labeling icon buttons.

---
*PR created automatically by Jules for task [3468493612919960704](https://jules.google.com/task/3468493612919960704) started by @kshramt*