### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce semantic HTTP status codes for auth failures

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-19 - Proper Semantic HTTP Status Codes for Auth Failures
+**Vulnerability:** Missing/invalid tokens and authorization failures returned generic 400 Bad Request instead of 401 Unauthorized / 403 Forbidden.
+**Learning:** Returning 400 Bad Request for auth failures can obscure actual security events from monitoring tools, preventing automated detection of unauthorized access attempts or credential stuffing.
+**Prevention:** Always enforce semantic HTTP status codes (401 for authentication, 403 for authorization) in API error handling logic to ensure security tooling can correctly classify and alert on failed auth events.

--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -9,6 +9,8 @@ use tracing::error;
 #[derive(Debug)]
 pub enum ErrorStatus {
     Status400,
+    Status401,
+    Status403,
     Status500,
 }
 
@@ -18,6 +20,8 @@ impl std::fmt::Display for ErrorStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ErrorStatus::Status400 => write!(f, "Status400"),
+            ErrorStatus::Status401 => write!(f, "Status401"),
+            ErrorStatus::Status403 => write!(f, "Status403"),
             ErrorStatus::Status500 => write!(f, "Status500"),
         }
     }
@@ -43,6 +47,16 @@ impl IntoResponse for ErrorStatus {
             ErrorStatus::Status400 => (
                 StatusCode::BAD_REQUEST,
                 Json(json!({"error": "Bad request."})),
+            )
+                .into_response(),
+            ErrorStatus::Status401 => (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "Unauthorized."})),
+            )
+                .into_response(),
+            ErrorStatus::Status403 => (
+                StatusCode::FORBIDDEN,
+                Json(json!({"error": "Forbidden."})),
             )
                 .into_response(),
             ErrorStatus::Status500 => (

--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -54,11 +54,9 @@ impl IntoResponse for ErrorStatus {
                 Json(json!({"error": "Unauthorized."})),
             )
                 .into_response(),
-            ErrorStatus::Status403 => (
-                StatusCode::FORBIDDEN,
-                Json(json!({"error": "Forbidden."})),
-            )
-                .into_response(),
+            ErrorStatus::Status403 => {
+                (StatusCode::FORBIDDEN, Json(json!({"error": "Forbidden."}))).into_response()
+            }
             ErrorStatus::Status500 => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "Something went wrong."})),

--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -7,6 +7,7 @@ use serde_json::json;
 use tracing::error;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum ErrorStatus {
     Status400,
     Status401,

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -36,7 +36,7 @@ where
         let TypedHeader(Authorization(bearer)) = parts
             .extract::<TypedHeader<Authorization<Bearer>>>()
             .await
-            .map_err(|_| errors::ErrorStatus::Status400)?;
+            .map_err(|_| errors::ErrorStatus::Status401)?;
         Self::from_base64(bearer.token())
     }
 }
@@ -45,15 +45,15 @@ impl gen::IdToken {
     pub fn from_base64(s: &str) -> Result<Self, errors::ErrorStatus> {
         let s = base64::engine::general_purpose::STANDARD
             .decode(s)
-            .map_err(|_| errors::ErrorStatus::Status400)?;
-        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status400)
+            .map_err(|_| errors::ErrorStatus::Status401)?;
+        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status401)
     }
 
     pub fn authorize(&self, user_id: &str) -> Result<(), errors::ErrorStatus> {
         if self.user_id == user_id {
             Ok(())
         } else {
-            Err(errors::ErrorStatus::Status400)
+            Err(errors::ErrorStatus::Status403)
         }
     }
 }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;


### PR DESCRIPTION
- 🚨 Severity: MEDIUM
- 💡 Vulnerability: Auth extraction and authorization failures returning generic 400 Bad Request.
- 🎯 Impact: Security logging and monitoring tools cannot distinguish between generic client errors and actual unauthorized access attempts.
- 🔧 Fix: Updated the `ErrorStatus` enum to use 401 Unauthorized for missing/invalid tokens and 403 Forbidden for authorization logic failures.
- ✅ Verification: Run `cargo check` and `cargo test` in `api_v2`.

---
*PR created automatically by Jules for task [13722706756434658124](https://jules.google.com/task/13722706756434658124) started by @kshramt*