### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix generic status codes on auth failures

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Incorrect HTTP Status for Authorization Failures
+**Vulnerability:** Authorization failures in `IdToken::authorize` and token extraction failures in `IdToken::from_request_parts` and `IdToken::from_base64` returned `400 Bad Request` instead of `403 Forbidden` and `401 Unauthorized`, respectively. This is a generic status code that does not communicate the correct security context, which may lead to clients not handling security errors correctly (like forcing a re-login on 401).
+**Learning:** Returning `Status400` on security failures is a bad practice. It should be `Status401` or `Status403` to reflect the semantic meaning of the error and help clients or proxies respond properly.
+**Prevention:** Use appropriate HTTP status codes for authentication/authorization failures. Specifically `Status401` for missing/invalid credentials and `Status403` for authorization failure (authenticated, but lack permissions).

--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -7,8 +7,11 @@ use serde_json::json;
 use tracing::error;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum ErrorStatus {
     Status400,
+    Status401,
+    Status403,
     Status500,
 }
 
@@ -18,6 +21,8 @@ impl std::fmt::Display for ErrorStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ErrorStatus::Status400 => write!(f, "Status400"),
+            ErrorStatus::Status401 => write!(f, "Status401"),
+            ErrorStatus::Status403 => write!(f, "Status403"),
             ErrorStatus::Status500 => write!(f, "Status500"),
         }
     }
@@ -45,6 +50,14 @@ impl IntoResponse for ErrorStatus {
                 Json(json!({"error": "Bad request."})),
             )
                 .into_response(),
+            ErrorStatus::Status401 => (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "Unauthorized."})),
+            )
+                .into_response(),
+            ErrorStatus::Status403 => {
+                (StatusCode::FORBIDDEN, Json(json!({"error": "Forbidden."}))).into_response()
+            }
             ErrorStatus::Status500 => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "Something went wrong."})),

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -36,7 +37,7 @@ where
         let TypedHeader(Authorization(bearer)) = parts
             .extract::<TypedHeader<Authorization<Bearer>>>()
             .await
-            .map_err(|_| errors::ErrorStatus::Status400)?;
+            .map_err(|_| errors::ErrorStatus::Status401)?;
         Self::from_base64(bearer.token())
     }
 }
@@ -45,15 +46,15 @@ impl gen::IdToken {
     pub fn from_base64(s: &str) -> Result<Self, errors::ErrorStatus> {
         let s = base64::engine::general_purpose::STANDARD
             .decode(s)
-            .map_err(|_| errors::ErrorStatus::Status400)?;
-        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status400)
+            .map_err(|_| errors::ErrorStatus::Status401)?;
+        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status401)
     }
 
     pub fn authorize(&self, user_id: &str) -> Result<(), errors::ErrorStatus> {
         if self.user_id == user_id {
             Ok(())
         } else {
-            Err(errors::ErrorStatus::Status400)
+            Err(errors::ErrorStatus::Status403)
         }
     }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Generic 400 Bad Request returned for authentication and authorization failures in `IdToken::authorize` and `IdToken::from_request_parts`/`IdToken::from_base64`.
🎯 Impact: Clients might not correctly interpret security errors (e.g., they might not re-login on 401 Unauthorized), which could lead to mismanaged sessions or improper caching.
🔧 Fix: Implemented specific 401 Unauthorized for invalid/missing tokens and 403 Forbidden for insufficient permissions (invalid user_id match).
✅ Verification: Tested using `cargo test` and `vitest`. Also recorded critical finding in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9829388070916504558](https://jules.google.com/task/9829388070916504558) started by @kshramt*