### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Semantic Error Status Codes for Auth

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-21 - Semantic Error Status Codes for Auth
+**Vulnerability:** The application was previously returning a generic 400 Bad Request for both token extraction failures (unauthenticated) and IDOR authorization logic failures (forbidden), losing critical semantic security context.
+**Learning:** Returning 400 Bad Request instead of 401/403 hides security-relevant context, complicating security auditing and rate-limiting responses based on unauthorized access attempts.
+**Prevention:** Use specific semantic HTTP statuses (`StatusCode::UNAUTHORIZED` and `StatusCode::FORBIDDEN`) for missing/invalid token extraction and authorization logic failures respectively.

--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -9,6 +9,8 @@ use tracing::error;
 #[derive(Debug)]
 pub enum ErrorStatus {
     Status400,
+    Status401,
+    Status403,
     Status500,
 }
 
@@ -18,6 +20,8 @@ impl std::fmt::Display for ErrorStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ErrorStatus::Status400 => write!(f, "Status400"),
+            ErrorStatus::Status401 => write!(f, "Status401"),
+            ErrorStatus::Status403 => write!(f, "Status403"),
             ErrorStatus::Status500 => write!(f, "Status500"),
         }
     }
@@ -43,6 +47,16 @@ impl IntoResponse for ErrorStatus {
             ErrorStatus::Status400 => (
                 StatusCode::BAD_REQUEST,
                 Json(json!({"error": "Bad request."})),
+            )
+                .into_response(),
+            ErrorStatus::Status401 => (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "Unauthorized."})),
+            )
+                .into_response(),
+            ErrorStatus::Status403 => (
+                StatusCode::FORBIDDEN,
+                Json(json!({"error": "Forbidden."})),
             )
                 .into_response(),
             ErrorStatus::Status500 => (

--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -54,11 +54,9 @@ impl IntoResponse for ErrorStatus {
                 Json(json!({"error": "Unauthorized."})),
             )
                 .into_response(),
-            ErrorStatus::Status403 => (
-                StatusCode::FORBIDDEN,
-                Json(json!({"error": "Forbidden."})),
-            )
-                .into_response(),
+            ErrorStatus::Status403 => {
+                (StatusCode::FORBIDDEN, Json(json!({"error": "Forbidden."}))).into_response()
+            }
             ErrorStatus::Status500 => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "Something went wrong."})),

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -36,7 +36,7 @@ where
         let TypedHeader(Authorization(bearer)) = parts
             .extract::<TypedHeader<Authorization<Bearer>>>()
             .await
-            .map_err(|_| errors::ErrorStatus::Status400)?;
+            .map_err(|_| errors::ErrorStatus::Status401)?;
         Self::from_base64(bearer.token())
     }
 }
@@ -45,15 +45,15 @@ impl gen::IdToken {
     pub fn from_base64(s: &str) -> Result<Self, errors::ErrorStatus> {
         let s = base64::engine::general_purpose::STANDARD
             .decode(s)
-            .map_err(|_| errors::ErrorStatus::Status400)?;
-        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status400)
+            .map_err(|_| errors::ErrorStatus::Status401)?;
+        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status401)
     }
 
     pub fn authorize(&self, user_id: &str) -> Result<(), errors::ErrorStatus> {
         if self.user_id == user_id {
             Ok(())
         } else {
-            Err(errors::ErrorStatus::Status400)
+            Err(errors::ErrorStatus::Status403)
         }
     }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application previously returned a generic 400 Bad Request for both token extraction failures (unauthenticated) and IDOR authorization logic failures (forbidden).
🎯 Impact: Returning 400 Bad Request instead of 401/403 hides critical security-relevant context, complicating security auditing, logging, and rate-limiting responses based on unauthorized access attempts.
🔧 Fix: Added `Status401` and `Status403` to `ErrorStatus` mapping to `StatusCode::UNAUTHORIZED` and `StatusCode::FORBIDDEN`. Updated token parsing (`from_request_parts` and `from_base64`) to return 401. Updated `authorize` checks to return 403.
✅ Verification: Backend unit tests and cargo checks pass successfully. Error codes are correctly implemented in Axum's `IntoResponse`.

---
*PR created automatically by Jules for task [14265778489229753126](https://jules.google.com/task/14265778489229753126) started by @kshramt*