### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-21 - Component Memoization Performance Tuning
+**Learning:** Virtualized lists like `Rv.Virtuoso` map over large datasets. Components inside these lists, such as `QueueEntry`, are frequently re-rendered when the queue state updates, leading to a large number of React component calls even if their individual props (`node_id`, `index`) haven't changed. We can optimize this by wrapping list item components in `React.memo()`.
+**Action:** Always wrap components rendered inside list structures (like `QueueEntry`, `TodoQueueEntry`, `NonTodoQueueEntry`, `TreeEntry`) with `React.memo` to prevent O(N) re-renders, especially when complex selectors are involved downstream.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,120 +17,127 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders inside the virtualized list when queue updates occur
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
-const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
-  const isTodo =
-    utils.assertV(
+const _QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const isTodo =
+      utils.assertV(
+        useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
+      ) === "todo";
+
+    return isTodo ? (
+      <TodoQueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <NonTodoQueueEntry node_id={props.node_id} index={props.index} />
+    );
+  },
+);
+_QueueEntry.displayName = "_QueueEntry";
+
+const NonTodoQueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const status = utils.assertV(
       useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
-    ) === "todo";
+    );
+    const to_tree = utils.useToTree(props.node_id);
+    const handleKeyDown = hooks.useTaskShortcutKeys(
+      props.node_id,
+      consts.TREE_PREFIX,
+    );
+    const id = utils.queue_textarea_id_of(props.node_id);
 
-  return isTodo ? (
-    <TodoQueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <NonTodoQueueEntry node_id={props.node_id} index={props.index} />
-  );
-};
-
-const NonTodoQueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const status = utils.assertV(
-    useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
-  );
-  const to_tree = utils.useToTree(props.node_id);
-  const handleKeyDown = hooks.useTaskShortcutKeys(
-    props.node_id,
-    consts.TREE_PREFIX,
-  );
-  const id = utils.queue_textarea_id_of(props.node_id);
-
-  return (
-    <EntryWrapper node_id={props.node_id} component="div">
-      <div className="flex items-end w-fit">
-        <TextArea
-          node_id={props.node_id}
-          id={id}
-          className={utils.join(
-            "w-[29em] px-[0.75em] py-[0.5em]",
-            status === "done"
-              ? "text-red-600 dark:text-red-400"
-              : status === "dont"
-                ? "text-neutral-500"
-                : null,
-          )}
-          onKeyDown={handleKeyDown}
-        />
-        <EntryInfos node_id={props.node_id} />
-      </div>
-      <EntryButtons
-        node_id={props.node_id}
-        jumpButton={<button onClick={to_tree}>←</button>}
-      />
-    </EntryWrapper>
-  );
-};
-
-const TodoQueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
-  const leaf_estimates_sum = utils.assertV(
-    useSelector(
-      (state) => state.swapped_caches.leaf_estimates_sum?.[props.node_id],
-    ),
-  );
-  const percentiles = utils.assertV(
-    useSelector((state) => state.swapped_caches.percentiles?.[props.node_id]),
-  );
-  const text = utils.assertV(
-    useSelector((state) => state.swapped_caches.text?.[props.node_id]),
-  );
-  const toTree = utils.useToTree(props.node_id);
-  const isRunning = utils.useIsRunning(props.node_id);
-
-  return (
-    <>
-      <div
-        className={utils.join(
-          "flex items-baseline gap-x-[0.25em] pb-[0.125em] w-[51em]",
-          isRunning && "running",
-        )}
-      >
-        <div className="flex items-baseline gap-x-[0.25em] w-[22em]">
-          <span className="w-[5em] text-right">{props.index}</span>
-          <TopButton node_id={props.node_id} />
-          <TodoToDoneButton node_id={props.node_id} />
-          <TodoToDontButton node_id={props.node_id} />
-          <ShowDetailsButton node_id={props.node_id} />
-          <CopyNodeIdButton node_id={props.node_id} />
-          <StartOrStopButtons node_id={props.node_id} />
+    return (
+      <EntryWrapper node_id={props.node_id} component="div">
+        <div className="flex items-end w-fit">
+          <TextArea
+            node_id={props.node_id}
+            id={id}
+            className={utils.join(
+              "w-[29em] px-[0.75em] py-[0.5em]",
+              status === "done"
+                ? "text-red-600 dark:text-red-400"
+                : status === "dont"
+                  ? "text-neutral-500"
+                  : null,
+            )}
+            onKeyDown={handleKeyDown}
+          />
+          <EntryInfos node_id={props.node_id} />
         </div>
-        <span
-          className="w-[16em] inline-block whitespace-nowrap overflow-hidden cursor-pointer"
-          title={text}
-          onClick={toTree}
-          role="button"
-          tabIndex={0}
+        <EntryButtons
+          node_id={props.node_id}
+          jumpButton={<button onClick={to_tree}>←</button>}
+        />
+      </EntryWrapper>
+    );
+  },
+);
+NonTodoQueueEntry.displayName = "NonTodoQueueEntry";
+
+const TodoQueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const leaf_estimates_sum = utils.assertV(
+      useSelector(
+        (state) => state.swapped_caches.leaf_estimates_sum?.[props.node_id],
+      ),
+    );
+    const percentiles = utils.assertV(
+      useSelector((state) => state.swapped_caches.percentiles?.[props.node_id]),
+    );
+    const text = utils.assertV(
+      useSelector((state) => state.swapped_caches.text?.[props.node_id]),
+    );
+    const toTree = utils.useToTree(props.node_id);
+    const isRunning = utils.useIsRunning(props.node_id);
+
+    return (
+      <>
+        <div
+          className={utils.join(
+            "flex items-baseline gap-x-[0.25em] pb-[0.125em] w-[51em]",
+            isRunning && "running",
+          )}
         >
-          {text}
-        </span>
-        <EntryInfos node_id={props.node_id} />
-      </div>
-      <div>
-        {0 <= leaf_estimates_sum && utils.digits1(leaf_estimates_sum) + " | "}
-        {percentiles.map(utils.digits1).join(", ")}
-      </div>
-    </>
-  );
-};
+          <div className="flex items-baseline gap-x-[0.25em] w-[22em]">
+            <span className="w-[5em] text-right">{props.index}</span>
+            <TopButton node_id={props.node_id} />
+            <TodoToDoneButton node_id={props.node_id} />
+            <TodoToDontButton node_id={props.node_id} />
+            <ShowDetailsButton node_id={props.node_id} />
+            <CopyNodeIdButton node_id={props.node_id} />
+            <StartOrStopButtons node_id={props.node_id} />
+          </div>
+          <span
+            className="w-[16em] inline-block whitespace-nowrap overflow-hidden cursor-pointer"
+            title={text}
+            onClick={toTree}
+            role="button"
+            tabIndex={0}
+          >
+            {text}
+          </span>
+          <EntryInfos node_id={props.node_id} />
+        </div>
+        <div>
+          {0 <= leaf_estimates_sum && utils.digits1(leaf_estimates_sum) + " | "}
+          {percentiles.map(utils.digits1).join(", ")}
+        </div>
+      </>
+    );
+  },
+);
+TodoQueueEntry.displayName = "TodoQueueEntry";


### PR DESCRIPTION
⚡ Bolt: Memoize QueueEntry components inside virtualized list

💡 What:
Wrapped `QueueEntry`, `_QueueEntry`, `NonTodoQueueEntry`, and `TodoQueueEntry` with `React.memo` and added `.displayName` attributes.

🎯 Why:
The `QueueEntry` components are repeatedly mapped over inside a virtualized list (`Rv.Virtuoso`). When Redux or Jotai states update elsewhere in the app causing re-renders, the list tries to re-render all visible queue entries. Wrapping these components in `React.memo` prevents unnecessary O(N) React renders because their primary props (`node_id`, `index`) rarely change unless the specific row shifts.

📊 Impact:
Reduces useless React component evaluation cycles for unaffected items in the queue when unrelated state changes occur. This improves scrolling performance and overall responsiveness of the main view.

🔬 Measurement:
Use React DevTools Profiler to record a trace before and after this change while interacting with the application (e.g., ticking off an item). Notice a significant reduction in the number of "QueueEntry" component calls that are grayed out (memoized).

---
*PR created automatically by Jules for task [2370146989480102109](https://jules.google.com/task/2370146989480102109) started by @kshramt*