### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to core action buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,8 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add"
+      title="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      aria-label="Stop"
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to three core icon-only buttons (`StartButton`, `StopButton`, and `AddButton`).

### 🎯 Why
These buttons are primary interactive elements but currently rely solely on Material Icons without proper screen reader text or native hover tooltips, making them ambiguous for some users.

### 📸 Before/After
Before: Icon-only buttons with no accessible names or tooltips.
After: Buttons announce their function to screen readers ("Start", "Stop", "Add") and display native browser tooltips on hover.

### ♿ Accessibility
Greatly improves keyboard and screen reader accessibility by providing clear, concise `aria-labels` and `titles` for these action buttons, reducing cognitive load.

---
*PR created automatically by Jules for task [16278897455404706753](https://jules.google.com/task/16278897455404706753) started by @kshramt*