### PR TITLE
⚡ Bolt: Optimize QueueEntry with React.memo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - React.memo on Virtualized List Items
+**Learning:** Even though Virtuoso limits DOM nodes, un-memoized list components like QueueEntry can still experience unnecessary React render cycles when the parent context or store triggers updates. This causes O(N) React render overhead for all visible items.
+**Action:** Always wrap top-level list item components (e.g., QueueEntry) in `React.memo` and append `displayName` to ensure React DevTools readability while preventing re-render cascades.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders when parent list components re-render, improving scroll performance in large queues.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
What: Wrapped `QueueEntry` in `React.memo` and added `displayName`.
Why: Un-memoized list components suffer from unnecessary React render cycles when parent components or contexts update.
Impact: Reduces React re-renders for visible list items, improving scroll and interaction performance.
Measurement: Verify via React DevTools Profiler that `QueueEntry` components do not re-render when they receive identical props.

---
*PR created automatically by Jules for task [3138332271396538045](https://jules.google.com/task/3138332271396538045) started by @kshramt*