### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix authentication and authorization error status codes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-23 - Proper HTTP Status Codes for Authentication & Authorization
+**Vulnerability:** The application was returning a generic 400 Bad Request instead of 401 Unauthorized for invalid/missing tokens, and 400 instead of 403 Forbidden for failed authorization checks (IDOR attempts).
+**Learning:** Overloading generic error codes (like 400) masks true security events (authentication failures vs authorization failures) and makes security logging, rate limiting, and alerting much less effective.
+**Prevention:** Always implement and enforce semantically correct HTTP status codes (401 for authentication, 403 for authorization) in the global error handler to ensure proper security observability.

--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -9,6 +9,8 @@ use tracing::error;
 #[derive(Debug)]
 pub enum ErrorStatus {
     Status400,
+    Status401,
+    Status403,
     Status500,
 }
 
@@ -18,6 +20,8 @@ impl std::fmt::Display for ErrorStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ErrorStatus::Status400 => write!(f, "Status400"),
+            ErrorStatus::Status401 => write!(f, "Status401"),
+            ErrorStatus::Status403 => write!(f, "Status403"),
             ErrorStatus::Status500 => write!(f, "Status500"),
         }
     }
@@ -43,6 +47,16 @@ impl IntoResponse for ErrorStatus {
             ErrorStatus::Status400 => (
                 StatusCode::BAD_REQUEST,
                 Json(json!({"error": "Bad request."})),
+            )
+                .into_response(),
+            ErrorStatus::Status401 => (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "Unauthorized."})),
+            )
+                .into_response(),
+            ErrorStatus::Status403 => (
+                StatusCode::FORBIDDEN,
+                Json(json!({"error": "Forbidden."})),
             )
                 .into_response(),
             ErrorStatus::Status500 => (

--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -54,11 +54,9 @@ impl IntoResponse for ErrorStatus {
                 Json(json!({"error": "Unauthorized."})),
             )
                 .into_response(),
-            ErrorStatus::Status403 => (
-                StatusCode::FORBIDDEN,
-                Json(json!({"error": "Forbidden."})),
-            )
-                .into_response(),
+            ErrorStatus::Status403 => {
+                (StatusCode::FORBIDDEN, Json(json!({"error": "Forbidden."}))).into_response()
+            }
             ErrorStatus::Status500 => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "Something went wrong."})),

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -36,7 +36,7 @@ where
         let TypedHeader(Authorization(bearer)) = parts
             .extract::<TypedHeader<Authorization<Bearer>>>()
             .await
-            .map_err(|_| errors::ErrorStatus::Status400)?;
+            .map_err(|_| errors::ErrorStatus::Status401)?;
         Self::from_base64(bearer.token())
     }
 }
@@ -45,15 +45,15 @@ impl gen::IdToken {
     pub fn from_base64(s: &str) -> Result<Self, errors::ErrorStatus> {
         let s = base64::engine::general_purpose::STANDARD
             .decode(s)
-            .map_err(|_| errors::ErrorStatus::Status400)?;
-        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status400)
+            .map_err(|_| errors::ErrorStatus::Status401)?;
+        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status401)
     }
 
     pub fn authorize(&self, user_id: &str) -> Result<(), errors::ErrorStatus> {
         if self.user_id == user_id {
             Ok(())
         } else {
-            Err(errors::ErrorStatus::Status400)
+            Err(errors::ErrorStatus::Status403)
         }
     }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The API returned 400 Bad Request instead of 401/403 for authentication/authorization failures.
🎯 Impact: Makes it harder to track unauthorized access attempts or distinguish between bad requests and security incidents.
🔧 Fix: Implemented `Status401` and `Status403` in `ErrorStatus` and applied them to `from_request_parts` and `authorize` methods.
✅ Verification: Verify through backend unit testing and ensuring frontend tests still pass.

---
*PR created automatically by Jules for task [9574661318161406682](https://jules.google.com/task/9574661318161406682) started by @kshramt*