### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,7 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add."
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,7 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Undo."
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,7 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start."
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done."
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Delete."
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
**What:** Added descriptive `aria-label` attributes to the `StartButton`, `AddButton`, `TodoToDoneButton`, `TodoToDontButton`, and `DoneOrDontToTodoButton` components.
**Why:** Icon-only buttons without accessible names cannot be understood by screen readers. Adding `aria-label` ensures all users can navigate and understand the primary actions available in the UI.
**Before/After:** The visual UI remains unchanged. The semantic HTML is updated to include `aria-label` for screen reader accessibility.
**Accessibility:** Improved screen reader support for critical application actions.

---
*PR created automatically by Jules for task [17928212774811898747](https://jules.google.com/task/17928212774811898747) started by @kshramt*