### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/errors.rs
+++ b/api_v2/src/errors.rs
@@ -9,6 +9,8 @@ use tracing::error;
 #[derive(Debug)]
 pub enum ErrorStatus {
     Status400,
+    Status401,
+    Status403,
     Status500,
 }
 
@@ -18,6 +20,8 @@ impl std::fmt::Display for ErrorStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ErrorStatus::Status400 => write!(f, "Status400"),
+            ErrorStatus::Status401 => write!(f, "Status401"),
+            ErrorStatus::Status403 => write!(f, "Status403"),
             ErrorStatus::Status500 => write!(f, "Status500"),
         }
     }
@@ -45,6 +49,14 @@ impl IntoResponse for ErrorStatus {
                 Json(json!({"error": "Bad request."})),
             )
                 .into_response(),
+            ErrorStatus::Status401 => (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "Unauthorized."})),
+            )
+                .into_response(),
+            ErrorStatus::Status403 => {
+                (StatusCode::FORBIDDEN, Json(json!({"error": "Forbidden."}))).into_response()
+            }
             ErrorStatus::Status500 => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "Something went wrong."})),

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -36,7 +36,7 @@ where
         let TypedHeader(Authorization(bearer)) = parts
             .extract::<TypedHeader<Authorization<Bearer>>>()
             .await
-            .map_err(|_| errors::ErrorStatus::Status400)?;
+            .map_err(|_| errors::ErrorStatus::Status401)?;
         Self::from_base64(bearer.token())
     }
 }
@@ -45,15 +45,15 @@ impl gen::IdToken {
     pub fn from_base64(s: &str) -> Result<Self, errors::ErrorStatus> {
         let s = base64::engine::general_purpose::STANDARD
             .decode(s)
-            .map_err(|_| errors::ErrorStatus::Status400)?;
-        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status400)
+            .map_err(|_| errors::ErrorStatus::Status401)?;
+        serde_json::from_slice(&s).map_err(|_| errors::ErrorStatus::Status401)
     }
 
     pub fn authorize(&self, user_id: &str) -> Result<(), errors::ErrorStatus> {
         if self.user_id == user_id {
             Ok(())
         } else {
-            Err(errors::ErrorStatus::Status400)
+            Err(errors::ErrorStatus::Status403)
         }
     }
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM

💡 Vulnerability: The API returned a generic `400 Bad Request` status code for both authentication failures (missing/invalid tokens) and authorization failures (accessing another user's resources).

🎯 Impact: Returning generic 400 errors instead of proper 401/403 status codes prevents standard HTTP tooling (proxies, load balancers, WAFs, automated monitoring) from accurately detecting, logging, or mitigating unauthorized access attempts.

🔧 Fix: 
- Added `Status401` and `Status403` to the `ErrorStatus` enum in `api_v2/src/errors.rs`.
- Implemented the `IntoResponse` trait to map these to `StatusCode::UNAUTHORIZED` and `StatusCode::FORBIDDEN`.
- Updated `token.authorize()` and `Self::from_base64()` in `api_v2/src/main.rs` to return the appropriate, semantically correct error statuses.

✅ Verification: Verified code by running backend linting and test suites (`cargo clippy`, `cargo test`) and the frontend test suite. Ensure all tests pass.

---
*PR created automatically by Jules for task [8771158528761484560](https://jules.google.com/task/8771158528761484560) started by @kshramt*