### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing API security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-25 - API Security Headers Bypass
+**Vulnerability:** Missing HTTP security headers (CSP, X-Content-Type-Options, X-Frame-Options) on `/api/v2/` responses.
+**Learning:** Envoy routes `/api/v2/` directly to the `api_v2_service`, bypassing the `nginx.conf` where HTML security headers are configured.
+**Prevention:** API services must configure their own security headers directly in the backend (e.g., via `tower_http` in Axum) rather than relying on the frontend proxy.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,19 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none';"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing HTTP security headers (Content-Security-Policy, X-Content-Type-Options, X-Frame-Options) on API responses. Envoy routes `/api/v2/` directly to the `api_v2_service`, bypassing the `nginx.conf` where HTML security headers are configured. This leaves API clients potentially exposed to cross-site scripting (XSS), MIME-sniffing, and framing attacks if the responses are rendered.
🎯 Impact: While the direct impact on JSON APIs is generally lower than on HTML endpoints, missing these headers violates defense-in-depth principles. Without `X-Content-Type-Options: nosniff`, browsers might incorrectly sniff the MIME type of a response and execute it as a script. Without `X-Frame-Options`, the API could theoretically be framed in malicious sites, potentially aiding in side-channel data leaks or clickjacking.
🔧 Fix: Configured `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs` to explicitly append the missing headers to all responses generated by the Axum application.
✅ Verification: Tested via `cargo test` and `cargo check`. The Axum service now explicitly injects these headers into the HTTP response. A critical learning regarding Envoy routing bypassing Nginx has been documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17062617495522009320](https://jules.google.com/task/17062617495522009320) started by @kshramt*