### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons for accessibility

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,7 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add node"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/Calendar/AddButton.tsx
+++ b/client/src/Calendar/AddButton.tsx
@@ -19,7 +19,7 @@ const AddButton = (props: { timeId: string }) => {
     );
   }, [dispatch, props.timeId, nodeIds]);
   return (
-    <button className="btn-icon" onClick={handleClick}>
+    <button className="btn-icon" aria-label="Add event" onClick={handleClick}>
       {consts.ADD_MARK}
     </button>
   );

--- a/client/src/ShowDetailsButton/index.tsx
+++ b/client/src/ShowDetailsButton/index.tsx
@@ -109,6 +109,7 @@ export const ShowDetailsButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Show details"
       onClick={handleClick}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to three icon-only button components: `AddButton`, `Calendar/AddButton`, and `ShowDetailsButton`.
🎯 **Why:** These buttons rely purely on visual icons (`ADD_MARK`, `DETAIL_MARK`) to convey their function, rendering them unreadable and inaccessible to assistive technologies like screen readers.
📸 **Before/After:** Visually identical. Screen reader will now announce "Add node", "Add event", or "Show details" instead of ignoring the buttons or reading unhelpful element types.
♿ **Accessibility:** Fixes WCAG 4.1.2 Name, Role, Value violations for these interactive elements, providing proper context to visually impaired users.

---
*PR created automatically by Jules for task [1965141770438990887](https://jules.google.com/task/1965141770438990887) started by @kshramt*