### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -389,6 +389,22 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none';"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
* Severity: MEDIUM
* Vulnerability: API endpoints lacked explicit HTTP security headers (CSP, X-Content-Type-Options, X-Frame-Options, HSTS).
* Impact: Leaves the API vulnerable to MIME sniffing, clickjacking, and man-in-the-middle attacks.
* Fix: Configured explicit security headers via `tower_http::set_header::SetResponseHeaderLayer`.
* Verification: Code modifications have been verified using `git diff` and all test suites have been executed and passed.

---
*PR created automatically by Jules for task [17301692998156671651](https://jules.google.com/task/17301692998156671651) started by @kshramt*