### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to Move Up/Down buttons

### DIFF
--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -58,6 +58,7 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move up"
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
@@ -77,6 +78,7 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move down"
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
**What:**
Added `aria-label="Move up"` and `aria-label="Move down"` to the `MoveUpButton` and `MoveDownButton` components in `client/src/EntryButtons.tsx`.

**Why:**
These buttons use icons exclusively (`consts.MOVE_UP_MARK` and `consts.MOVE_DOWN_MARK`) and previously lacked any accessible name. This makes them difficult to understand for screen reader users.

**Before/After:**
Before: `<button className="btn-icon">...</button>`
After: `<button className="btn-icon" aria-label="Move up">...</button>`

**Accessibility:**
Improves accessibility for screen reader users by providing a clear, descriptive label for these icon-only buttons.

---
*PR created automatically by Jules for task [1960339845280007131](https://jules.google.com/task/1960339845280007131) started by @kshramt*