### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-28 - Add Security Headers to API
+**Vulnerability:** Missing security headers (CSP, X-Frame-Options, X-Content-Type-Options, HSTS) on the Rust API responses, exposing the API to various attacks like clickjacking and MIME sniffing.
+**Learning:** The application uses Nginx to handle frontend security headers, but Envoy routes API requests (`/api/v2/`) directly to the backend service. Therefore, Nginx security header configurations are bypassed for the API.
+**Prevention:** Configure security headers directly in the backend service using `tower_http::set_header::SetResponseHeaderLayer` in the Axum router, ensuring API responses are protected independently of the proxy layer.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -389,6 +390,22 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers (CSP, X-Frame-Options, X-Content-Type-Options, HSTS) on the Rust API responses, exposing the API to various attacks like clickjacking and MIME sniffing.
🎯 Impact: The API is vulnerable to basic browser-based attacks such as MIME-sniffing and clickjacking.
🔧 Fix: Configure security headers directly in the backend service using `tower_http::set_header::SetResponseHeaderLayer` in the Axum router, ensuring API responses are protected independently of the proxy layer.
✅ Verification: The API backend tests pass and we can inspect the response headers in dev or prod manually to check they are present.

---
*PR created automatically by Jules for task [14202332145789758232](https://jules.google.com/task/14202332145789758232) started by @kshramt*