### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders when parent lists (like VirtualizedQueueNodes) update, optimizing large list rendering.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 **What**: Wrapped `QueueEntry` with `React.memo` and added a `displayName`.
🎯 **Why**: Re-rendering large lists (like the queue) on parent state changes can block the main thread; memoization avoids this.
📊 **Impact**: Prevents unnecessary O(N) re-renders of queue items when the parent updates.
🔬 **Measurement**: Verify using React DevTools Profiler that `QueueEntry` components do not re-render unless `node_id` or `index` changes.

---
*PR created automatically by Jules for task [14092011791678511941](https://jules.google.com/task/14092011791678511941) started by @kshramt*