### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add"
+      title="Add"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/EntryButtons.tsx
+++ b/client/src/EntryButtons.tsx
@@ -61,6 +61,8 @@ const MoveUpButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveUpButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move up"
+      title="Move up"
     >
       {consts.MOVE_UP_MARK}
     </button>
@@ -80,6 +82,8 @@ const MoveDownButton = (props: { node_id: types.TNodeId }) => {
       onClick={on_click}
       ref={moveDownButtonRefOf(props.node_id)}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Move down"
+      title="Move down"
     >
       {consts.MOVE_DOWN_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>


### PR DESCRIPTION
### What
Added `aria-label` and `title` attributes to four icon-only buttons: `AddButton`, `MoveUpButton`, `MoveDownButton`, and `StartButton`.

### Why
Icon-only buttons rely entirely on their visual representation (in this case, Material Icons). Without explicit text labels, screen reader users cannot determine the purpose of these buttons, making the interface confusing or unusable. Adding `aria-label` solves this by providing a hidden label for assistive technologies, while `title` provides a helpful native tooltip for mouse users who might not recognize the icon.

### Before/After
* **Before:** Buttons only contained the icon text (e.g., `add`, `north`, `south`, `play_arrow`) inside the element, which could be misread or offer poor context. They had no tooltips.
* **After:** Buttons explicitly announce their function (e.g., "Add", "Move up") to screen readers and display a tooltip on hover.

### Accessibility
This change ensures compliance with WCAG 2.1 Success Criterion 4.1.2 (Name, Role, Value) by explicitly providing accessible names for these critical interactive controls.

---
*PR created automatically by Jules for task [11079185352388097076](https://jules.google.com/task/11079185352388097076) started by @kshramt*