### PR TITLE
⚡ Bolt: Add React.memo to QueueEntry to prevent unnecessary re-renders

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders of list items in Virtuoso
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 **What**: Wrapped the `QueueEntry` component inside `React.memo` and assigned `QueueEntry.displayName = 'QueueEntry'`. Added a required `// ⚡ Bolt` explanatory comment inline.

🎯 **Why**: Unmemoized child components rendered in a mapping function (especially inside `react-virtuoso` lists) re-render unnecessarily whenever their parent updates, causing an `O(N)` performance penalty that can degrade rendering performance in large queues.

📊 **Impact**: Expected to reduce unnecessary re-renders of the queue list items to near zero, significantly improving interface responsiveness during layout updates.

🔬 **Measurement**: Can be verified by using React DevTools Profiler with "Record why each component rendered while profiling" enabled. Comparing traces before and after this change will show `QueueEntry` components skipping re-renders when only parent states update.

---
*PR created automatically by Jules for task [12905620127054028307](https://jules.google.com/task/12905620127054028307) started by @kshramt*