### PR TITLE
⚡ Bolt: [performance improvement] React.memo for QueueEntry components

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,120 +17,130 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
 
-const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
-  const isTodo =
-    utils.assertV(
+QueueEntry.displayName = "QueueEntry";
+// ⚡ Bolt: React.memo prevents unnecessary re-renders when parent lists update
+
+const _QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const isTodo =
+      utils.assertV(
+        useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
+      ) === "todo";
+
+    return isTodo ? (
+      <TodoQueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <NonTodoQueueEntry node_id={props.node_id} index={props.index} />
+    );
+  },
+);
+
+_QueueEntry.displayName = "_QueueEntry";
+
+const NonTodoQueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const status = utils.assertV(
       useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
-    ) === "todo";
+    );
+    const to_tree = utils.useToTree(props.node_id);
+    const handleKeyDown = hooks.useTaskShortcutKeys(
+      props.node_id,
+      consts.TREE_PREFIX,
+    );
+    const id = utils.queue_textarea_id_of(props.node_id);
 
-  return isTodo ? (
-    <TodoQueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <NonTodoQueueEntry node_id={props.node_id} index={props.index} />
-  );
-};
-
-const NonTodoQueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const status = utils.assertV(
-    useSelector((state) => state.swapped_nodes.status?.[props.node_id]),
-  );
-  const to_tree = utils.useToTree(props.node_id);
-  const handleKeyDown = hooks.useTaskShortcutKeys(
-    props.node_id,
-    consts.TREE_PREFIX,
-  );
-  const id = utils.queue_textarea_id_of(props.node_id);
-
-  return (
-    <EntryWrapper node_id={props.node_id} component="div">
-      <div className="flex items-end w-fit">
-        <TextArea
-          node_id={props.node_id}
-          id={id}
-          className={utils.join(
-            "w-[29em] px-[0.75em] py-[0.5em]",
-            status === "done"
-              ? "text-red-600 dark:text-red-400"
-              : status === "dont"
-                ? "text-neutral-500"
-                : null,
-          )}
-          onKeyDown={handleKeyDown}
-        />
-        <EntryInfos node_id={props.node_id} />
-      </div>
-      <EntryButtons
-        node_id={props.node_id}
-        jumpButton={<button onClick={to_tree}>←</button>}
-      />
-    </EntryWrapper>
-  );
-};
-
-const TodoQueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
-  const leaf_estimates_sum = utils.assertV(
-    useSelector(
-      (state) => state.swapped_caches.leaf_estimates_sum?.[props.node_id],
-    ),
-  );
-  const percentiles = utils.assertV(
-    useSelector((state) => state.swapped_caches.percentiles?.[props.node_id]),
-  );
-  const text = utils.assertV(
-    useSelector((state) => state.swapped_caches.text?.[props.node_id]),
-  );
-  const toTree = utils.useToTree(props.node_id);
-  const isRunning = utils.useIsRunning(props.node_id);
-
-  return (
-    <>
-      <div
-        className={utils.join(
-          "flex items-baseline gap-x-[0.25em] pb-[0.125em] w-[51em]",
-          isRunning && "running",
-        )}
-      >
-        <div className="flex items-baseline gap-x-[0.25em] w-[22em]">
-          <span className="w-[5em] text-right">{props.index}</span>
-          <TopButton node_id={props.node_id} />
-          <TodoToDoneButton node_id={props.node_id} />
-          <TodoToDontButton node_id={props.node_id} />
-          <ShowDetailsButton node_id={props.node_id} />
-          <CopyNodeIdButton node_id={props.node_id} />
-          <StartOrStopButtons node_id={props.node_id} />
+    return (
+      <EntryWrapper node_id={props.node_id} component="div">
+        <div className="flex items-end w-fit">
+          <TextArea
+            node_id={props.node_id}
+            id={id}
+            className={utils.join(
+              "w-[29em] px-[0.75em] py-[0.5em]",
+              status === "done"
+                ? "text-red-600 dark:text-red-400"
+                : status === "dont"
+                  ? "text-neutral-500"
+                  : null,
+            )}
+            onKeyDown={handleKeyDown}
+          />
+          <EntryInfos node_id={props.node_id} />
         </div>
-        <span
-          className="w-[16em] inline-block whitespace-nowrap overflow-hidden cursor-pointer"
-          title={text}
-          onClick={toTree}
-          role="button"
-          tabIndex={0}
+        <EntryButtons
+          node_id={props.node_id}
+          jumpButton={<button onClick={to_tree}>←</button>}
+        />
+      </EntryWrapper>
+    );
+  },
+);
+
+NonTodoQueueEntry.displayName = "NonTodoQueueEntry";
+
+const TodoQueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const leaf_estimates_sum = utils.assertV(
+      useSelector(
+        (state) => state.swapped_caches.leaf_estimates_sum?.[props.node_id],
+      ),
+    );
+    const percentiles = utils.assertV(
+      useSelector((state) => state.swapped_caches.percentiles?.[props.node_id]),
+    );
+    const text = utils.assertV(
+      useSelector((state) => state.swapped_caches.text?.[props.node_id]),
+    );
+    const toTree = utils.useToTree(props.node_id);
+    const isRunning = utils.useIsRunning(props.node_id);
+
+    return (
+      <>
+        <div
+          className={utils.join(
+            "flex items-baseline gap-x-[0.25em] pb-[0.125em] w-[51em]",
+            isRunning && "running",
+          )}
         >
-          {text}
-        </span>
-        <EntryInfos node_id={props.node_id} />
-      </div>
-      <div>
-        {0 <= leaf_estimates_sum && utils.digits1(leaf_estimates_sum) + " | "}
-        {percentiles.map(utils.digits1).join(", ")}
-      </div>
-    </>
-  );
-};
+          <div className="flex items-baseline gap-x-[0.25em] w-[22em]">
+            <span className="w-[5em] text-right">{props.index}</span>
+            <TopButton node_id={props.node_id} />
+            <TodoToDoneButton node_id={props.node_id} />
+            <TodoToDontButton node_id={props.node_id} />
+            <ShowDetailsButton node_id={props.node_id} />
+            <CopyNodeIdButton node_id={props.node_id} />
+            <StartOrStopButtons node_id={props.node_id} />
+          </div>
+          <span
+            className="w-[16em] inline-block whitespace-nowrap overflow-hidden cursor-pointer"
+            title={text}
+            onClick={toTree}
+            role="button"
+            tabIndex={0}
+          >
+            {text}
+          </span>
+          <EntryInfos node_id={props.node_id} />
+        </div>
+        <div>
+          {0 <= leaf_estimates_sum && utils.digits1(leaf_estimates_sum) + " | "}
+          {percentiles.map(utils.digits1).join(", ")}
+        </div>
+      </>
+    );
+  },
+);
+TodoQueueEntry.displayName = "TodoQueueEntry";


### PR DESCRIPTION
### 💡 What
Wrapped `QueueEntry` components (`QueueEntry`, `_QueueEntry`, `NonTodoQueueEntry`, `TodoQueueEntry`) with `React.memo` in `client/src/QueueEntry.tsx`. Added `displayName` properties for React DevTools compatibility.

### 🎯 Why
These components are rendered repeatedly inside `react-virtuoso` lists (`VirtualizedQueueNodes`). Without memoization, any state change in the parent list (like scrolling, filtering, or unrelated updates in `components.tsx`) forces a re-render of all visible queue entries. This O(N) re-render behavior is a common performance bottleneck in React applications rendering long lists.

### 📊 Impact
Reduces unnecessary re-renders in large queue lists. `React.memo` ensures these components only re-render when their specific primitive props (`node_id`, `index`) change, delegating the responsibility of state-driven updates entirely to their internal `useSelector` hooks. This makes the frontend measurably faster during queue interactions.

### 🔬 Measurement
Verify using the React DevTools Profiler. Record a session while scrolling or interacting with the queue list. Observe that `QueueEntry` components and their children do not re-render unnecessarily when unrelated parent state changes occur.

---
*PR created automatically by Jules for task [15666846410543692392](https://jules.google.com/task/15666846410543692392) started by @kshramt*