### PR TITLE
🎨 Palette: Add accessible tooltips to task action buttons

### DIFF
--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label={is_copied ? "Copied node ID" : "Copy node ID"}
+      title={is_copied ? "Copied node ID" : "Copy node ID"}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Undo status"
+      title="Undo status"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
+      title="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as won't do"
+      title="Mark as won't do"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
- 💡 **What**: Added `aria-label` and native `title` tooltips to key task action icon buttons (Copy Node ID, Mark as Done, Mark as Won't Do, Undo Status).
- 🎯 **Why**: These icon-only buttons lacked descriptive text, making their functions ambiguous to mouse users and completely inaccessible to screen readers.
- 📸 **Before/After**: Before, hovering provided no context and screen readers only read generic HTML element data or the unicode character. After, descriptive tooltips appear on hover and screen readers announce the exact actions.
- ♿ **Accessibility**: Provides robust screen reader support and hover descriptions, enabling clearer interaction paths.

---
*PR created automatically by Jules for task [8618737694278949521](https://jules.google.com/task/8618737694278949521) started by @kshramt*