### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to icon-only action buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add child node"
+      title="Add child node"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
+      title="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as won't do"
+      title="Mark as won't do"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to several core icon-only action buttons across the application (`AddButton`, `StartButton`, `StartConcurrentButton`, `TodoToDoneButton`, `TodoToDontButton`).

🎯 **Why:** Icon-only buttons without accessible names are completely invisible to screen readers, leaving visually impaired users guessing what the button does. Additionally, adding `title` attributes provides native browser tooltips on hover, which helps clarify the action for mouse users.

📸 **Before/After:**
*   **Before:** `<button className="btn-icon" ...>{consts.START_MARK}</button>`
*   **After:** `<button className="btn-icon" aria-label="Start" title="Start" ...>{consts.START_MARK}</button>`

♿ **Accessibility:**
*   **Screen Readers:** Users will now hear a descriptive label (e.g., "Start button", "Add child node button") instead of just "button".
*   **Sighted Users:** Hovering over the buttons now reveals a tooltip explaining their function, reducing ambiguity.

---
*PR created automatically by Jules for task [1130190490077863675](https://jules.google.com/task/1130190490077863675) started by @kshramt*