### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,20 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        // 🛡️ Sentinel: Add HTTP security headers to prevent XSS, MIME sniffing, and Clickjacking
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** Missing HTTP Security Headers on the API backend.
**Impact:** While the frontend is protected by Nginx, API responses served by the `api_v2` service lack standard security headers. This omission leaves the API potentially exposed to MIME sniffing attacks, Clickjacking (if endpoints are improperly framed), and reduces the defense-in-depth against XSS.
**Fix:** Added `Content-Security-Policy` (`default-src 'none'; frame-ancestors 'none'`), `X-Content-Type-Options` (`nosniff`), and `X-Frame-Options` (`DENY`) using `tower_http::set_header::SetResponseHeaderLayer` to the global Axum router in `api_v2/src/main.rs`.
**Verification:** Verified by checking the Git diff, ensuring `cargo check` passes without new errors, and confirming `cargo test` passes.

---
*PR created automatically by Jules for task [17936497784347579898](https://jules.google.com/task/17936497784347579898) started by @kshramt*