### PR TITLE
⚡ Bolt: Add React.memo to QueueEntry

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders when parent lists update
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
## 💡 What
Added `React.memo` to the `QueueEntry` component and set its `displayName` for easier debugging.
I also added an inline comment explaining the optimization.

## 🎯 Why
`QueueEntry` is the core item component used heavily in virtualized lists (via Virtuoso) across the application. When the parent list component's state updates, it re-renders all visible `QueueEntry` components in an O(N) fashion, even if the specific `node_id` or `index` props for a given entry haven't changed. By wrapping it in `React.memo`, React will skip rendering for entries whose props haven't changed, saving cycles.

## 📊 Impact
Expected to reduce unnecessary component re-renders for list items, leading to smoother scrolling and quicker list updates, especially noticeable on lower-end devices or when the list size is large.

## 🔬 Measurement
You can verify the improvement using the React DevTools Profiler. Record a session while updating global state or parent lists that contain `QueueEntry` components. You should observe that `QueueEntry` components are marked as "Memoized" and do not re-render unless their specific `node_id` or `index` prop changes.

*(No journal entry was added because this is a standard React performance tip and did not yield a codebase-specific surprise/learning, adhering to Bolt's journaling guidelines.)*

---
*PR created automatically by Jules for task [16738950653329625542](https://jules.google.com/task/16738950653329625542) started by @kshramt*