### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to task action buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Undo"
+      title="Undo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
+      title="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Delete"
+      title="Delete"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
- What: Added `aria-label` and `title` attributes to icon-only task action buttons (Add, Done, Delete, Undo).
- Why: To improve usability for sighted users by providing hover tooltips, and improve accessibility for screen reader users by providing clear context for icon-only buttons.
- Before/After: Buttons were icon-only with no accessible name or tooltip. Now they have semantic labels and visual tooltips on hover.
- Accessibility: Added `aria-label` to ensure icon-only buttons have an accessible name for assistive technologies.

---
*PR created automatically by Jules for task [5089757846887230447](https://jules.google.com/task/5089757846887230447) started by @kshramt*