### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -389,6 +389,18 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("frame-ancestors 'none';"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
- Severity: MEDIUM
- Vulnerability: Missing HTTP security headers on API responses.
- Impact: Increased risk of MIME-sniffing, clickjacking, and XSS on API endpoints.
- Fix: Configured `tower_http::set_header::SetResponseHeaderLayer` in the Axum router to set standard security headers.
- Verification: Verified headers compile locally via cargo.

---
*PR created automatically by Jules for task [2315232911273133956](https://jules.google.com/task/2315232911273133956) started by @kshramt*