### PR TITLE
⚡ Bolt: Memoize QueueEntry to prevent unnecessary list re-renders

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders of list items when their props (node_id and index) haven't changed.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped QueueEntry in React.memo().
🎯 Why: QueueEntry is rendered in a list. Without React.memo(), an update that causes the parent to re-render will force O(N) re-renders of all QueueEntry components, even if their node_id and index props haven't changed.
📊 Impact: Prevents unnecessary O(N) re-renders of list items during parent component updates.
🔬 Measurement: Observe React DevTools Profiler during state updates that affect the parent list but not individual items; QueueEntry components should not re-render unless their specific props change.

---
*PR created automatically by Jules for task [17522482002100823093](https://jules.google.com/task/17522482002100823093) started by @kshramt*