### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders of queue list items when parent re-renders and props (node_id, index) remain unchanged.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped \`QueueEntry\` in \`React.memo\` and added \`displayName\`. \n🎯 Why: Prevents unnecessary O(N) re-renders of queue list items when the parent list component re-renders but item props haven't changed. \n📊 Impact: Reduces list item re-renders during parent updates. \n🔬 Measurement: Verify with React DevTools Profiler by triggering list state changes and observing that unmodified \`QueueEntry\` items are skipped during the render phase.

---
*PR created automatically by Jules for task [6456041445139630277](https://jules.google.com/task/6456041445139630277) started by @kshramt*