### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -7,19 +7,20 @@ use axum_extra::{
     headers::{authorization::Bearer, Authorization},
     TypedHeader,
 };
-use hyper::header;
-use tower_http::set_header::SetResponseHeaderLayer;
 use base64::Engine;
+use hyper::header;
 use serde_json::json;
 use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -7,6 +7,8 @@ use axum_extra::{
     headers::{authorization::Bearer, Authorization},
     TypedHeader,
 };
+use hyper::header;
+use tower_http::set_header::SetResponseHeaderLayer;
 use base64::Engine;
 use serde_json::json;
 use std::{
@@ -390,7 +392,23 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::CONTENT_SECURITY_POLICY,
+            header::HeaderValue::from_static("default-src 'none'"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::STRICT_TRANSPORT_SECURITY,
+            header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/v2/` endpoints were lacking standard security HTTP headers (e.g., Content-Security-Policy, X-Frame-Options), which are bypassed by Envoy and not served by Nginx.
🎯 Impact: This missing defense-in-depth makes the API more susceptible to certain types of attacks, even if it primarily serves JSON.
🔧 Fix: Configured `tower_http::set_header::SetResponseHeaderLayer` in `api_v2/src/main.rs` to inject fundamental security headers.
✅ Verification: Ran `cargo test` and `cargo check` to ensure successful compilation and application functionality.

---
*PR created automatically by Jules for task [11243892685289769688](https://jules.google.com/task/11243892685289769688) started by @kshramt*