### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to core action buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,8 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add"
+      title="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      aria-label="Stop"
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
💡 What: Added aria-label and title attributes to core icon-only buttons (Start, Stop, Start Concurrently, Add).
🎯 Why: Icon-only buttons lacked tooltips on hover for mouse users and explicit ARIA labels for screen readers, making them harder to discover and understand.
📸 Before/After: Before, buttons lacked tooltips. After, hovering displays native tooltips and screen readers can read the action.
♿ Accessibility: Improved screen reader support by ensuring focusable icon buttons have clear descriptive labels.

---
*PR created automatically by Jules for task [10464507989036000091](https://jules.google.com/task/10464507989036000091) started by @kshramt*