### PR TITLE
🎨 Palette: [UX improvement]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-26 - Add ARIA Labels and Tooltips to Icon-Only Buttons
+**Learning:** Icon-only buttons used in lists/grids require `aria-label` for screen reader accessibility and `title` to provide hover tooltips for mouse users, clarifying their purpose.
+**Action:** Always verify if an icon-only button requires accessible naming and tooltips in shared components.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add child node"
+      title="Add child node"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Revert to todo"
+      title="Revert to todo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
+      title="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as don't do"
+      title="Mark as don't do"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
## What
Added `aria-label` and `title` attributes to icon-only action buttons (Add, Done, Don't Do, Undo).

## Why
Improves accessibility for screen readers and provides helpful tooltips for users interacting with the buttons.

## Before/After
Before: Icon-only buttons lacked accessible names and hover tooltips.
After: Buttons have clear accessible names and helpful tooltips.

## Accessibility
Added appropriate `aria-label` attributes to ensure buttons are correctly announced by screen readers.

---
*PR created automatically by Jules for task [4610193690354116592](https://jules.google.com/task/4610193690354116592) started by @kshramt*