### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to primary icon buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      aria-label="Stop"
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
### What
Added `aria-label` and `title` attributes to the Add and Start icon-only buttons, and updated Stop button to include a `title`.
### Why
Icon-only buttons without tooltips leave sighted users guessing their function, and without ARIA labels, they are invisible to screen readers.
### Before/After
Before: Buttons only had icons and no descriptive text or tooltips.
After: Buttons now display a native tooltip on hover and announce their action to screen readers.
### Accessibility
Improved screen reader compatibility and discoverability by adding standard `aria-label` and `title` attributes to critical icon-only buttons.

---
*PR created automatically by Jules for task [8978506456309403201](https://jules.google.com/task/8978506456309403201) started by @kshramt*