### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    // ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders when parent list state changes but this specific entry's props remain unchanged.
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
**💡 What:** Wrapped the `QueueEntry` component in `React.memo` and added the `displayName` property for easier debugging.

**🎯 Why:** In virtualized or long lists (such as the queue list powered by `Virtuoso`), individual entry components can experience unnecessary O(N) re-renders when the parent list state changes, even if the props of a specific entry remain unchanged. `React.memo` prevents this behavior, ensuring that `QueueEntry` only re-renders when its specific `node_id` or `index` props change, or when its internal selector (`exists`) evaluates to a different result.

**📊 Impact:** Expected to reduce unnecessary re-renders of list items during general list scrolling and state updates within the parent queue view, making the UI noticeably more responsive and efficient as the queue grows in size.

**🔬 Measurement:** This can be verified by observing React DevTools Profiler while interacting with the queue list (e.g., adding/removing/swapping items) to see that unmodified `QueueEntry` components are skipped during re-renders.

---
*PR created automatically by Jules for task [8394877872402262924](https://jules.google.com/task/8394877872402262924) started by @kshramt*