### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,23 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none';"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: API responses from the `api_v2` backend lacked standard HTTP security headers (CSP, X-Content-Type-Options, X-Frame-Options, HSTS). The application relied on Nginx for HTML headers, but API requests routed directly to the backend bypassed this configuration.
🎯 Impact: Missing security headers leave the API susceptible to content sniffing, clickjacking on exposed endpoints, and lack of forced secure transport via HSTS.
🔧 Fix: Added `SetResponseHeaderLayer` middleware to the Axum Router in `api_v2/src/main.rs` to enforce strong security headers (`Content-Security-Policy: default-src 'none'; frame-ancestors 'none';`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Strict-Transport-Security: max-age=31536000; includeSubDomains`) directly at the backend level.
✅ Verification: Run `cargo run` in `api_v2`, make an API request to an endpoint (e.g., `/sys/health`), and verify the presence of the security headers in the response.

---
*PR created automatically by Jules for task [15227282434539201044](https://jules.google.com/task/15227282434539201044) started by @kshramt*