### PR TITLE
⚡ Bolt: Wrap QueueEntry in React.memo

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders of list items when parent container updates.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped QueueEntry in React.memo and assigned a displayName.
🎯 Why: QueueEntry is rendered inside mapping functions (like QueueNodes) and virtualized lists. Without memoization, list items re-render unnecessarily when their parent container re-renders.
📊 Impact: Reduces unnecessary re-renders of the QueueEntry component by O(N), improving rendering performance in large lists.
🔬 Measurement: Use React Profiler to verify that QueueEntry list items do not re-render unless their props (node_id, index) or specific selectors (exists) update.

---
*PR created automatically by Jules for task [3347209843113278591](https://jules.google.com/task/3347209843113278591) started by @kshramt*