### PR TITLE
⚡ Bolt: Add React.memo to QueueEntry

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders when parent components update.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped QueueEntry in React.memo.
🎯 Why: Prevents unnecessary O(N) re-renders when parent components update.
📊 Impact: Reduces React rendering time for lists by skipping components whose props have not changed.
🔬 Measurement: Use React Profiler to verify that QueueEntry does not re-render when its props remain the same.

---
*PR created automatically by Jules for task [6672852864821023007](https://jules.google.com/task/6672852864821023007) started by @kshramt*