### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,7 +391,19 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
Severity: Medium

Vulnerability: Missing API security headers. The Axum API did not have standard security headers like X-Content-Type-Options, X-Frame-Options, or Content-Security-Policy configured. Because Envoy routes directly to the API (bypassing Nginx), these headers must be set in the Axum application.
     
Impact: Browsers interacting directly with the API could be vulnerable to MIME-type sniffing or clickjacking if responses were mishandled or if the API ever serves HTML content.
     
Fix: Configured the SetResponseHeaderLayer in tower-http to enforce 'nosniff', 'DENY', and 'default-src \'none\'' on all Axum routes.
     
Verification: Local testing and Cargo tests pass. Ensure headers are present in the response from API endpoints.

---
*PR created automatically by Jules for task [17066371150782819450](https://jules.google.com/task/17066371150782819450) started by @kshramt*