### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    // ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders when the parent re-renders.
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrap QueueEntry in React.memo and set displayName.
🎯 Why: QueueEntry is rendered in lists. Unnecessary re-renders occur when the parent list component re-renders but the item's props remain unchanged.
📊 Impact: Reduces O(N) re-renders when parent re-renders.
🔬 Measurement: Profiling React DevTools before and after during queue re-orders or parent updates.

---
*PR created automatically by Jules for task [12161181374051349644](https://jules.google.com/task/12161181374051349644) started by @kshramt*