### PR TITLE
🎨 Palette: [UX improvement]

### DIFF
--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -25,6 +25,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label={is_copied ? "Copied" : "Copy node ID"}
+      title={is_copied ? "Copied" : "Copy node ID"}
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>


### PR DESCRIPTION
💡 What: Added aria-label and title attributes to the copy node ID icon button.
🎯 Why: Icon-only buttons without labels are difficult for screen reader users to understand and mouse users to decipher.
📸 Before/After: Before, just an icon. After, the button has a helpful tooltip on hover and screen reader support.
♿ Accessibility: Improved screen reader compatibility by explicitly defining the button's action and state (copied vs default).

---
*PR created automatically by Jules for task [16708260417646940034](https://jules.google.com/task/16708260417646940034) started by @kshramt*