### PR TITLE
🎨 Palette: Add ARIA labels to icon-only action buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,7 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,7 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Undo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,7 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as don't"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,7 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}


### PR DESCRIPTION
### 💡 What
Added accessible names (`aria-label`) to multiple icon-only action buttons across the application (`AddButton`, `StartButton`, `DoneOrDontToTodoButton`, `TodoToDoneButton`, `TodoToDontButton`, `TopButton`).

### 🎯 Why
Screen readers will read these icon-only buttons simply as "button" if they lack an `aria-label` or visible text. Providing an accessible name ensures screen reader users understand the specific action each button performs, improving overall navigability and usability.

### 📸 Before/After
- **Before:** `<button className="btn-icon">{consts.ADD_MARK}</button>` (Screen reader: "button")
- **After:** `<button className="btn-icon" aria-label="Add">{consts.ADD_MARK}</button>` (Screen reader: "Add, button")

### ♿ Accessibility
Significantly improves accessibility for assistive technology users by providing explicit, actionable names for key UI interactions, directly addressing potential WCAG 4.1.2 (Name, Role, Value) issues on core application controls.

---
*PR created automatically by Jules for task [12710045185056128402](https://jules.google.com/task/12710045185056128402) started by @kshramt*