### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,7 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add."
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,7 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to Todo."
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/EvalButton.tsx
+++ b/client/src/EvalButton.tsx
@@ -15,6 +15,7 @@ export const EvalButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Evaluate."
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,7 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start."
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,7 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently."
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as Done."
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as Don't."
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,7 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to Top."
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}


### PR DESCRIPTION
What: Added descriptive `aria-label` attributes to multiple icon-only buttons (`<button className="btn-icon">`) across the application.
Why: Icon-only buttons without `aria-label` or `title` attributes are completely opaque to screen readers, which will simply announce "button". This change ensures visually impaired users can understand the purpose of each button (e.g., "Start.", "Evaluate.", "Move to Todo.").
Before/After: N/A (Functional accessibility change, no visual layout changes).
Accessibility: Directly improves compliance with WCAG success criteria related to name, role, and value by providing accessible names for controls.

---
*PR created automatically by Jules for task [11559804067911292373](https://jules.google.com/task/11559804067911292373) started by @kshramt*