### PR TITLE
🛡️ Sentinel: [security improvement] Add missing security headers to API

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -8,16 +8,19 @@ use axum_extra::{
     TypedHeader,
 };
 use base64::Engine;
+use hyper::header;
 use serde_json::json;
 use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,6 +393,18 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(SetResponseHeaderLayer::overriding(
+            header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static("frame-ancestors 'none';"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 
     let port = get_server_port();


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing standard HTTP security headers on API responses (`Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`). The current application proxy (Envoy) routes `/api/v2/` directly to the `api_v2` Rust service, completely bypassing Nginx, which was configured to apply security headers. 
🎯 **Impact:** Browsers could potentially interpret API responses maliciously (e.g., MIME sniffing vulnerabilities or clickjacking, although less applicable for APIs, it weakens the overall security baseline). 
🔧 **Fix:** Added Axum middleware via `tower_http::set_header::SetResponseHeaderLayer::overriding()` to explicitly set `CONTENT_SECURITY_POLICY`, `X_CONTENT_TYPE_OPTIONS`, and `X_FRAME_OPTIONS` on all responses served by the `api_v2` backend. 
✅ **Verification:** Run `cargo test` in `api_v2` to verify compilation and backend server functionality. Observe responses from the API now contain the specified security headers.

---
*PR created automatically by Jules for task [15176451215796296827](https://jules.google.com/task/15176451215796296827) started by @kshramt*