### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and titles to icon buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add"
+      title="Add"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -16,6 +16,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}
+      aria-label="Move to top"
+      title="Move to top"
     >
       {consts.TOP_MARK}
     </button>


### PR DESCRIPTION
What: Added aria-label and title attributes to AddButton, StartButton, and TopButton.
Why: These buttons are icon-only and lacked proper accessible names and tooltip titles, making them hard to use for screen reader users or when their icons are ambiguous.
Before/After: Buttons now announce their actions properly to screen readers and display a tooltip on hover.
Accessibility: Improved ARIA compliance for interactive elements.

---
*PR created automatically by Jules for task [9360582043898516384](https://jules.google.com/task/9360582043898516384) started by @kshramt*