### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to start and stop buttons

### DIFF
--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      aria-label="Stop"
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to `StartButton`, `StartConcurrentButton`, and `StopButton`.
🎯 Why: Improves accessibility for screen readers and provides native tooltips on hover for icon-only buttons to clarify their function.
📸 Before/After: Buttons were icon-only with no hover text. Now they display descriptive tooltips and provide screen reader context.
♿ Accessibility: Improved screen reader announcements and hover state context.

---
*PR created automatically by Jules for task [3374212073472133280](https://jules.google.com/task/3374212073472133280) started by @kshramt*