### PR TITLE
⚡ Bolt: Memoize QueueEntry for performance improvement

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders of list items in virtualized lists.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
What: Wrapped QueueEntry component in React.memo and added displayName property.
Why: Prevents unnecessary O(N) re-renders of list items in virtualized lists when parent components update without changing node_id or index.
Impact: Reduces main thread blocking time during list rendering and improves scrolling performance.
Measurement: Compare React Profiler metrics (specifically render duration and frequency for QueueEntry components) before and after changes when interacting with the task list.

---
*PR created automatically by Jules for task [14714873872255762249](https://jules.google.com/task/14714873872255762249) started by @kshramt*