### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -389,6 +390,10 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
Adding a default-src 'none' Content-Security-Policy header to the API endpoints to ensure they are explicitly locked down from a CSP perspective.

---
*PR created automatically by Jules for task [7775810967642088742](https://jules.google.com/task/7775810967642088742) started by @kshramt*