### PR TITLE
⚡ Bolt: Optimize QueueEntry with React.memo

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders of list items when parent re-renders.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
What: Wrapped the QueueEntry component in React.memo and added a displayName.
Why: QueueEntry receives primitive props (node_id and index) and is rendered in long lists. Memoization avoids unnecessary re-renders when parent components update.
Impact: Reduces unnecessary O(N) re-renders of list items when parent re-renders.
Measurement: Verify reduced re-renders of QueueEntry via React DevTools Profiler during parent updates.

---
*PR created automatically by Jules for task [15201496338777601778](https://jules.google.com/task/15201496338777601778) started by @kshramt*