### PR TITLE
🎨 Palette: [UX improvement] Add aria labels to icon buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,8 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add"
+      title="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/Calendar/AddButton.tsx
+++ b/client/src/Calendar/AddButton.tsx
@@ -19,7 +19,12 @@ const AddButton = (props: { timeId: string }) => {
     );
   }, [dispatch, props.timeId, nodeIds]);
   return (
-    <button className="btn-icon" onClick={handleClick}>
+    <button
+      className="btn-icon"
+      aria-label="Add"
+      title="Add"
+      onClick={handleClick}
+    >
       {consts.ADD_MARK}
     </button>
   );

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
Added aria-label and title attributes to AddButton, Calendar/AddButton, and StartButton components.
The components use icon-only buttons (styled as btn-icon) which rely on Material Icons without native text content, meaning screen readers miss their purpose.
Buttons now include descriptive text (e.g. aria-label="Add" and title="Add").
This change allows screen readers to correctly announce the buttons' functions and provides visual hover tooltips for all users.

---
*PR created automatically by Jules for task [1844667097394603427](https://jules.google.com/task/1844667097394603427) started by @kshramt*