### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to api_v2

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,23 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
Added SetResponseHeaderLayer configurations to the Axum router to enforce HSTS, prevent MIME sniffing, deny framing, and apply a strict default CSP in the rust API.

---
*PR created automatically by Jules for task [4409888646730028167](https://jules.google.com/task/4409888646730028167) started by @kshramt*