### PR TITLE
⚡ Bolt: [performance improvement] Wrap QueueEntry in React.memo

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders when parent lists update but the item props (node_id, index) remain unchanged.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped the `QueueEntry` component in `React.memo` and added a `displayName`.
🎯 Why: `QueueEntry` represents individual items in virtualized lists (using `react-virtuoso`). When parent list states update, these items would unnecessarily re-render even if their specific `node_id` and `index` props remained unchanged.
📊 Impact: Prevents unnecessary O(N) re-renders for list items, improving overall scrolling and update performance in the queue views.
🔬 Measurement: Verify via React DevTools Profiler that `QueueEntry` components do not re-render when sibling components or parent list non-item-specific states change.

---
*PR created automatically by Jules for task [5757568879645614919](https://jules.google.com/task/5757568879645614919) started by @kshramt*