### PR TITLE
🎨 Palette: Add ARIA label and tooltip to Start button

### DIFF
--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 What: Added an `aria-label` and `title` to the icon-only StartButton.
🎯 Why: To improve keyboard accessibility for screen readers and add visual tooltips on hover for users who may not understand the icon.
📸 Before/After: Visual tooltip "Start" appears on hover, and screen readers read "Start" instead of skipping the button.
♿ Accessibility: Added `aria-label="Start"` to make the icon-only button accessible to screen readers.

---
*PR created automatically by Jules for task [2119697285535406458](https://jules.google.com/task/2119697285535406458) started by @kshramt*