### PR TITLE
⚡ Bolt: Add React.memo to QueueEntry

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,21 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders of the queue items.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` in `React.memo` to optimize performance within virtualized queues.
🎯 Why: Items within a list component, especially those fed to `react-virtuoso`, frequently cause unnecessary O(N) re-renders if the parent component updates or iterates.
📊 Impact: This will significantly reduce re-renders when rendering `QueueEntry` items since their primitives (`node_id` and `index`) do not inherently mutate during parent tree renders.
🔬 Measurement: Render the frontend and inspect component re-renders through the React DevTools profiler extension.

---
*PR created automatically by Jules for task [8938602528970587371](https://jules.google.com/task/8938602528970587371) started by @kshramt*