### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,19 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

Severity: MEDIUM
Vulnerability: Missing security headers (X-Content-Type-Options, X-Frame-Options, Content-Security-Policy) on API endpoints, leaving the API open to MIME sniffing and clickjacking, and allowing potential unintended resource loading.
Impact: Attackers could potentially perform MIME sniffing attacks to execute malicious payloads or embed API responses in iframes for clickjacking attacks.
Fix: Added X-Content-Type-Options: nosniff, X-Frame-Options: DENY, and Content-Security-Policy headers using tower_http::set_header::SetResponseHeaderLayer in the api_v2 Axum router.
Verification: The headers are configured to be always sent on HTTP responses from api_v2.

---
*PR created automatically by Jules for task [15258636042169599582](https://jules.google.com/task/15258636042169599582) started by @kshramt*