### PR TITLE
⚡ Bolt: Optimize QueueEntry rendering with React.memo

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary re-renders in virtualized lists when props are unchanged, improving scroll performance and reducing CPU usage.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped QueueEntry component in React.memo and added a displayName.
🎯 Why: QueueEntry is frequently rendered inside virtualized lists. Without memoization, any parent re-render can unnecessarily trigger O(N) re-renders for all visible items.
📊 Impact: Reduces unnecessary React render cycles for QueueEntry items when props (node_id and index) are unchanged, minimizing CPU usage during list scrolls and updates.
🔬 Measurement: Profile the React component tree while scrolling the queue list. The render counts for QueueEntry will only increment when props change.

---
*PR created automatically by Jules for task [11897015018141939223](https://jules.google.com/task/11897015018141939223) started by @kshramt*