### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to core action buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Add subtask"
+      title="Add subtask"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start tracking"
+      title="Start tracking"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Mark as done"
+      title="Mark as done"
     >
       {consts.DONE_MARK}
     </button>

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Mark as won't do"
+      title="Mark as won't do"
     >
       {consts.DONT_MARK}
     </button>


### PR DESCRIPTION
This PR adds `aria-label` and `title` attributes to the following icon-only buttons:
- `AddButton.tsx`
- `TodoToDoneButton.tsx`
- `TodoToDontButton.tsx`
- `StartButton/index.tsx`

This change provides context for screen readers and tooltips for mouse users, improving the accessibility and usability of these core actions.

---
*PR created automatically by Jules for task [16142603975822978213](https://jules.google.com/task/16142603975822978213) started by @kshramt*