### PR TITLE
⚡ Bolt: Optimize QueueEntry rendering

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: React.memo prevents unnecessary O(N) re-renders for unchanged queue items
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped QueueEntry component in React.memo.
🎯 Why: To prevent unnecessary O(N) re-renders when parent components like QueueNodes or VirtualizedQueueNodes re-render but individual queue items have not changed.
📊 Impact: Reduces CPU cycles and improves scrolling/rendering performance of queue lists by bypassing reconciliation for unchanged queue items.
🔬 Measurement: Profile React renders in DevTools while scrolling or updating unrelated parent state; unchanged QueueEntry instances should no longer re-render.

---
*PR created automatically by Jules for task [324672307916031350](https://jules.google.com/task/324672307916031350) started by @kshramt*