### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -389,6 +390,22 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none';"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

🚨 Severity: MEDIUM
💡 Vulnerability: The API backend (api_v2) was missing standard HTTP security headers (Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, Strict-Transport-Security) because Envoy routed API requests directly to it, bypassing the Nginx server where they were set for the frontend.
🎯 Impact: Lack of these headers leaves the API vulnerable to cross-site scripting (XSS), MIME sniffing, clickjacking, and prevents enforcement of secure transport (HSTS).
🔧 Fix: Added the missing security headers explicitly in the `api_v2` Axum application router using `tower_http::set_header::SetResponseHeaderLayer`.
✅ Verification: Run `cargo check` and `cargo test` in the `api_v2` directory to ensure backend functionality is intact.

---
*PR created automatically by Jules for task [18042877644995415435](https://jules.google.com/task/18042877644995415435) started by @kshramt*