### PR TITLE
🎨 Palette: Add ARIA labels to main action buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -28,6 +28,7 @@ export const AddButton = (props: {
   return (
     <button
       className="btn-icon"
+      aria-label="Add"
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,7 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Undo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,7 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,7 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as don't"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
What: Added `aria-label` attributes to icon-only buttons (Add, Start, Done, Don't, Undo).
Why: Screen readers currently do not announce any meaningful label for these icon-only buttons, reducing accessibility.
Before/After: No visual change. Buttons now have descriptive ARIA labels.
Accessibility: Improves screen reader support and overall keyboard accessibility for core application actions.

---
*PR created automatically by Jules for task [7014439486119475240](https://jules.google.com/task/7014439486119475240) started by @kshramt*