### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/gen.rs
+++ b/api_v2/src/gen.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 #[rustfmt::skip]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct IdToken {

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,24 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        // 🛡️ Sentinel: Adding required API security headers
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_CONTENT_TYPE_OPTIONS,
+            hyper::header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::X_FRAME_OPTIONS,
+            hyper::header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::STRICT_TRANSPORT_SECURITY,
+            hyper::header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
Added required HTTP security headers (Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, Strict-Transport-Security) to the `api_v2` Axum application to protect API endpoints that bypass the Nginx frontend proxy.

---
*PR created automatically by Jules for task [18200577561521975818](https://jules.google.com/task/18200577561521975818) started by @kshramt*