### PR TITLE
⚡ Bolt: Add React.memo() to QueueEntry to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-24 - React.memo on Virtuoso item component
+**Learning:** In a virtualized list (like `react-virtuoso`), the item component (e.g., `QueueEntry`) is called frequently when scrolling. Using `React.memo` on the exported component avoids unnecessary re-renders of list items whose props (`node_id`, `index`) haven't changed, significantly improving scrolling performance and reducing main-thread blocking.
+**Action:** Always consider `React.memo` for components used as `itemContent` in virtualized lists.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,19 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped QueueEntry component in React.memo()
🎯 Why: In a virtualized list (react-virtuoso), item components are frequently re-rendered. By memoizing QueueEntry, we avoid re-rendering list items whose props (node_id, index) haven't changed.
📊 Impact: Significantly improves scrolling performance and reduces main-thread blocking by preventing unnecessary re-renders of list items.
🔬 Measurement: Use React Profiler while scrolling the queue to verify reduced render counts of QueueEntry components.

---
*PR created automatically by Jules for task [16695154373124518934](https://jules.google.com/task/16695154373124518934) started by @kshramt*