### PR TITLE
🎨 Palette: Add titles and ARIA labels to icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -31,6 +31,8 @@ export const AddButton = (props: {
       id={props.id}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      title="Add child task"
+      aria-label="Add child task"
     >
       {consts.ADD_MARK}
     </button>

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -25,6 +25,8 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
+      title="Copy task ID"
+      aria-label="Copy task ID"
     >
       {is_copied ? consts.DONE_MARK : consts.COPY_MARK}
     </button>

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      title="Start task"
+      aria-label="Start task"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      title="Stop task"
+      aria-label="Stop task"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
Added `title` and `aria-label` attributes to multiple icon-only buttons to improve accessibility and UX.

---
*PR created automatically by Jules for task [3290848489619434379](https://jules.google.com/task/3290848489619434379) started by @kshramt*