### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,7 +391,11 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            hyper::header::CONTENT_SECURITY_POLICY,
+            hyper::header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none';"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
Severity: MEDIUM
Vulnerability: Missing Content-Security-Policy security headers on API responses.
Impact: Defense-in-depth against XSS and clickjacking attacks is missing on the API layer if served outside the Nginx proxy.
Fix: Added Content-Security-Policy header (default-src 'none'; frame-ancestors 'none') to the Axum router using tower-http.
Verification: Ran cargo test and cargo clippy.

---
*PR created automatically by Jules for task [6715632195818768921](https://jules.google.com/task/6715632195818768921) started by @kshramt*