### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -20,20 +20,19 @@ import TopButton from "./TopButton";
 // ⚡ Bolt Optimization:
 // Wrapped QueueEntry in React.memo to prevent unnecessary re-renders of the list items when the parent container updates.
 // Expected Impact: Reduces React re-renders for large lists, improving scrolling and interaction performance.
-export const QueueEntry = React.memo((props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-});
-QueueEntry.displayName = 'QueueEntry';
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,10 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+// ⚡ Bolt Optimization:
+// Wrapped QueueEntry in React.memo to prevent unnecessary re-renders of the list items when the parent container updates.
+// Expected Impact: Reduces React re-renders for large lists, improving scrolling and interaction performance.
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +32,8 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
+QueueEntry.displayName = 'QueueEntry';
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
Wrapped QueueEntry in React.memo to prevent unnecessary re-renders of the list items when the parent container updates, which reduces React re-renders for large lists and improves scrolling and interaction performance.

---
*PR created automatically by Jules for task [18399428109456650034](https://jules.google.com/task/18399428109456650034) started by @kshramt*