### PR TITLE
🎨 Palette: [UX improvement] Add clear ARIA labels and tooltips to core action buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add child node"
+      title="Add child node"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start tracking"
+      title="Start tracking"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start tracking concurrently"
+      title="Start tracking concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      aria-label="Stop tracking"
+      title="Stop tracking"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
💡 What:
Added clear `aria-label` and `title` attributes to the Add, Start, Stop, and Start Concurrent icon-only buttons.

🎯 Why:
To ensure icon-only buttons are accessible to screen readers and provide hover tooltips for visual users, clarifying their purpose since they lack visible text labels.

📸 Before/After:
Before: `consts.ADD_MARK`, `consts.START_MARK`, `consts.STOP_MARK`, `consts.START_CONCURRNET_MARK` icon buttons had no `aria-label` or `title` attributes (except an unclear `aria-label="Stop."`).
After: Tooltips appear on hover and screen readers announce "Add child node", "Start tracking", "Stop tracking", and "Start tracking concurrently".

♿ Accessibility:
Significantly improves keyboard and screen reader accessibility by ensuring all core action buttons have explicit, descriptive labels.

---
*PR created automatically by Jules for task [9673687181213260487](https://jules.google.com/task/9673687181213260487) started by @kshramt*