### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,21 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: Wrapping QueueEntry in React.memo to prevent unnecessary re-renders when parent list components update.
+// This provides a measurable performance improvement for large virtualized queues as shallow prop comparison (node_id and index) skips redundant rendering cycles.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped QueueEntry in React.memo to prevent unnecessary re-renders.
🎯 Why: In large virtualized queues, components can redundantly re-render on parent state changes.
📊 Impact: Reduces redundant render cycles by skipping renders when the shallow prop comparison (node_id and index) matches.
🔬 Measurement: Can be verified using React DevTools profiler to observe skipped renders when parent components update.

---
*PR created automatically by Jules for task [10972772464651856040](https://jules.google.com/task/10972772464651856040) started by @kshramt*