### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Add Security Headers
+**Vulnerability:** Missing HTTP Security Headers in the Rust backend
+**Learning:** Axum backends must configure their own security headers, as API traffic bypasses Nginx.
+**Prevention:** Apply strict headers (CSP, X-Frame-Options, X-Content-Type-Options) to API middleware using `tower_http`.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -1,5 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Path, Query, State},
+    http::header,
     http::request::Parts,
     Json, RequestPartsExt,
 };
@@ -13,11 +14,13 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::{debug, info, instrument};
 use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -390,7 +393,21 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        // Security enhancement: Add strict HTTP security headers to API responses
+        // to mitigate XSS, Clickjacking, and MIME-sniffing vulnerabilities.
+        .layer(SetResponseHeaderLayer::overriding(
+            header::CONTENT_SECURITY_POLICY,
+            header::HeaderValue::from_static("default-src 'none'"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            header::HeaderValue::from_static("nosniff"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
Added strict HTTP security headers to API responses using tower_http's SetResponseHeaderLayer to mitigate XSS, Clickjacking, and MIME-sniffing vulnerabilities.

---
*PR created automatically by Jules for task [9259324981854261796](https://jules.google.com/task/9259324981854261796) started by @kshramt*