### PR TITLE
🎨 Palette: Add aria-label and title to icon-only buttons

### DIFF
--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -17,6 +17,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start"
+      title="Start"
     >
       {consts.START_MARK}
     </button>

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -17,6 +17,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      aria-label="Start concurrently"
+      title="Start concurrently"
     >
       {consts.START_CONCURRNET_MARK}
     </button>

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -16,6 +16,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}
+      aria-label="Move to top"
+      title="Move to top"
     >
       {consts.TOP_MARK}
     </button>


### PR DESCRIPTION
🎨 Palette: Add aria-label and title to icon-only buttons

💡 What: Added `aria-label` and `title` attributes to the `StartButton`, `StartConcurrentButton`, and `TopButton` components.
🎯 Why: Icon-only buttons lack accessible names and tooltips, making them difficult for screen reader users to understand and less intuitive for sighted users.
📸 Before/After: Before, buttons only had icons. After, buttons have screen-reader accessible names and hover tooltips.
♿ Accessibility: Improved screen reader navigation by ensuring all interactive icon buttons have descriptive names.

---
*PR created automatically by Jules for task [6466422612393747293](https://jules.google.com/task/6466422612393747293) started by @kshramt*