### PR TITLE
⚡ Bolt: Memoize QueueEntry component

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// Memoize QueueEntry to prevent unnecessary O(N) re-renders in lists
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
⚡ Bolt: Memoize QueueEntry component

💡 What: Wrapped the `QueueEntry` component in `React.memo` and explicitly set `QueueEntry.displayName`.
🎯 Why: `QueueEntry` is rendered in lists. When the parent component re-renders, it re-rendered all list items even if their primitive props (`node_id`, `index`) did not change, causing O(N) unnecessary renders.
📊 Impact: Prevents unnecessary O(N) re-renders in the queue list, which reduces CPU usage and improves list rendering performance.
🔬 Measurement: Verify with React DevTools Profiler that `QueueEntry` does not re-render when list sibling elements change or parent updates if `node_id` and `index` remain identical.

---
*PR created automatically by Jules for task [13954500576835644392](https://jules.google.com/task/13954500576835644392) started by @kshramt*