### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -390,7 +390,24 @@ async fn main() {
     let app = app.with_state(state);
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        // 🛡️ Sentinel: Add security headers to prevent XSS, clickjacking, and mime-sniffing
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static("default-src 'none'"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_CONTENT_TYPE_OPTIONS,
+            axum::http::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::X_FRAME_OPTIONS,
+            axum::http::HeaderValue::from_static("DENY"),
+        ))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🛡️ Sentinel: Add security headers to API responses

🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in API responses (CSP, X-Content-Type-Options, X-Frame-Options, HSTS).
🎯 Impact: Increased risk of XSS, clickjacking, and MIME-type sniffing attacks if endpoints inadvertently return HTML or other unexpected content types.
🔧 Fix: Configured tower_http::set_header::SetResponseHeaderLayer in the axum router to enforce strict security headers.
✅ Verification: Run `cargo test` in api_v2. Manual inspection of response headers.

---
*PR created automatically by Jules for task [8485166312041422522](https://jules.google.com/task/8485166312041422522) started by @kshramt*