### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and tooltips to icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Mark as done"
+      title="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Delete"
+      title="Delete"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add ARIA labels and tooltips to icon-only buttons

💡 What: Added aria-label and title attributes to core icon-only buttons (Add, Start, Done, Delete).
🎯 Why: Icon-only buttons lack context for screen readers and can be ambiguous for sighted users. The tooltips and ARIA labels provide clear, immediate context.
📸 Before/After: Buttons now show a native browser tooltip on hover and announce their purpose to screen readers.
♿ Accessibility: Improved keyboard and screen reader accessibility by ensuring interactive elements have descriptive labels.

---
*PR created automatically by Jules for task [695645201091577760](https://jules.google.com/task/695645201091577760) started by @kshramt*