### PR TITLE
🎨 Palette: Add ARIA labels to core icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,7 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add item"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/CopyNodeIdButton/index.tsx
+++ b/client/src/CopyNodeIdButton/index.tsx
@@ -23,6 +23,7 @@ const CopyNodeIdButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label={is_copied ? "Copied ID" : "Copy ID"}
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,7 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 What: Added ARIA labels to core icon-only buttons (AddButton, StartButton, and CopyNodeIdButton).
🎯 Why: To improve screen reader accessibility for icon-only buttons.
📸 Before/After: Not applicable (purely non-visual accessibility attributes).
♿ Accessibility: Improved screen reader announcements for core actions.

---
*PR created automatically by Jules for task [5720183394287116787](https://jules.google.com/task/5720183394287116787) started by @kshramt*