### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to icon-only buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to `StartButton` and `AddButton`.
🎯 Why: Icon-only buttons lack context for screen readers and visual users alike. Adding `aria-label` improves screen reader accessibility, and `title` adds a native tooltip for mouse users.
📸 Before/After: N/A (Non-visual changes and native tooltips)
♿ Accessibility: Provides explicit naming for assistive technologies on previously unlabeled icon buttons.

---
*PR created automatically by Jules for task [17773920282464585953](https://jules.google.com/task/17773920282464585953) started by @kshramt*