### PR TITLE
⚡ Bolt: Add React.memo to QueueEntry component

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,7 +17,9 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
+// ⚡ Bolt: Wrapped in React.memo to prevent unnecessary re-renders when parent list changes.
+// Performance impact: Reduces re-renders of list elements whose props (node_id/index) haven't changed.
+export const QueueEntry = React.memo((props: {
   node_id: types.TNodeId;
   index: number;
 }) => {
@@ -29,7 +31,8 @@ export const QueueEntry = (props: {
   ) : (
     <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
   );
-};
+});
+QueueEntry.displayName = 'QueueEntry';
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
💡 What: Wrapped `QueueEntry` component in `React.memo` and added explanatory comments.
🎯 Why: Prevents unnecessary re-renders of list elements when the parent component re-renders but the element's primitive props (`node_id` and `index`) have not changed.
📊 Impact: Reduces re-renders of the queue items in virtualized and standard lists, making the UI more responsive.
🔬 Measurement: Verify using React DevTools Profiler that `QueueEntry` doesn't re-render unless its `node_id` or `index` changes.

---
*PR created automatically by Jules for task [1452933527973799823](https://jules.google.com/task/1452933527973799823) started by @kshramt*