### PR TITLE
⚡ Bolt: Add React.memo to QueueEntry

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,22 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: Wrapped in React.memo to prevent unnecessary re-renders when parent list state changes.
+// 📊 Impact: Prevents list items from re-rendering if their specific node_id or index hasn't changed.
+// 🔬 Measurement: Verify with React Profiler by checking 'Record why each component rendered'.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
Wrapped `QueueEntry` in `React.memo` to prevent unnecessary list item re-renders when the parent list state changes, improving rendering performance for large lists. Added performance comments and `displayName` as per Bolt guidelines.

---
*PR created automatically by Jules for task [15453613770789741434](https://jules.google.com/task/15453613770789741434) started by @kshramt*