### PR TITLE
⚡ Bolt: Add React.memo to QueueEntry

### DIFF
--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,21 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// Performance optimization: Wrap QueueEntry in React.memo to prevent unnecessary re-renders
+// when rendered within virtualized lists, as props (node_id, index) rarely change.
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
Wrapped QueueEntry component in React.memo.
To prevent unnecessary re-renders of list items within virtualized lists, improving scroll performance.
Reduces React re-renders when list items do not have changed props.
Observe less re-rendering in React DevTools profiler while scrolling.

---
*PR created automatically by Jules for task [9302797791576737383](https://jules.google.com/task/9302797791576737383) started by @kshramt*