### PR TITLE
⚡ Bolt: Memoize QueueEntry component

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-08-06 - Memoized QueueEntry Component
+**Learning:** The QueueEntry component inside the Virtualized list in QueueNodes is mapped over large datasets. Without `React.memo`, updating one item triggers re-renders for all items inside the queue list (O(N)), which negatively impacts scrolling and list updating performance.
+**Action:** Applied `React.memo()` to prevent unneeded O(N) list renders in the queue.

--- a/client/src/QueueEntry.tsx
+++ b/client/src/QueueEntry.tsx
@@ -17,19 +17,20 @@ import * as types from "./types";
 import * as utils from "./utils";
 import TopButton from "./TopButton";
 
-export const QueueEntry = (props: {
-  node_id: types.TNodeId;
-  index: number;
-}) => {
-  const exists = useRawSelector((state) =>
-    Object.hasOwn(state.data.nodes, props.node_id),
-  );
-  return exists ? (
-    <_QueueEntry node_id={props.node_id} index={props.index} />
-  ) : (
-    <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
-  );
-};
+// ⚡ Bolt: Wrapped QueueEntry in React.memo to prevent O(N) re-renders when parent lists update
+export const QueueEntry = React.memo(
+  (props: { node_id: types.TNodeId; index: number }) => {
+    const exists = useRawSelector((state) =>
+      Object.hasOwn(state.data.nodes, props.node_id),
+    );
+    return exists ? (
+      <_QueueEntry node_id={props.node_id} index={props.index} />
+    ) : (
+      <div className="w-[1px] h-[1px]" /> // `null` is not allowed as Virtuoso does not allow 0-height elements.
+    );
+  },
+);
+QueueEntry.displayName = "QueueEntry";
 
 const _QueueEntry = (props: { node_id: types.TNodeId; index: number }) => {
   const isTodo =


### PR DESCRIPTION
⚡ Bolt: Memoize QueueEntry component

💡 What: Wrapped QueueEntry in React.memo() with explicit displayName.
🎯 Why: QueueEntry is rendered inside QueueNodes via map(). Without memoization, whenever the parent updates, all unmodified items undergo an unnecessary re-render (O(N) operation).
📊 Impact: Reduces rendering time for lists from O(N) to O(1) for untouched items, improving responsiveness.
🔬 Measurement: Profile React renders in DevTools when items are added to or updated in the queue list.

---
*PR created automatically by Jules for task [15882749799185757294](https://jules.google.com/task/15882749799185757294) started by @kshramt*