### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-06 - Accessible Icon-only Buttons
+**Learning:** Several action buttons in the UI were missing both visible tooltips (`title`) and accessible names (`aria-label`) for screen readers. Since they only visually display an icon, they were entirely inaccessible to keyboard and assistive technology users.
+**Action:** When adding new icon-only buttons, always ensure that they have a descriptive `title` attribute for mouse users and an `aria-label` for screen reader users.

--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      title="Add child"
+      aria-label="Add child"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -14,6 +14,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Undo"
+      aria-label="Undo"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Start"
+      aria-label="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      title="Stop"
+      aria-label="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Mark as done"
+      aria-label="Mark as done"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -16,6 +16,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      title="Mark as won't do"
+      aria-label="Mark as won't do"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >


### PR DESCRIPTION
🎨 Palette: Add tooltips and ARIA labels to action buttons

💡 What: Added `title` and `aria-label` attributes to Add, Start, Stop, Done, Dont, and Undo buttons.
🎯 Why: Icon-only buttons lacked visual tooltips on hover and accessible names for screen readers.
📸 Before/After: Buttons now display native tooltips on hover.
♿ Accessibility: Screen readers can now announce the action of each icon-only button.

---
*PR created automatically by Jules for task [746285737333878492](https://jules.google.com/task/746285737333878492) started by @kshramt*