### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/Cargo.toml
+++ b/api_v2/Cargo.toml
@@ -19,6 +19,6 @@ serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "macros", "uuid", "chrono", "json"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["full"] }
+tower-http = { version = "0.6", features = ["full", "set-header"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -388,9 +389,14 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
+    // 🛡️ Sentinel: Adding strict Content-Security-Policy headers to API responses to mitigate potential XSS and data injection attacks by ensuring no resources are loaded or executed unexpectedly.
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
+        .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024))
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static("default-src 'none'"),
+        ));
 
     let port = get_server_port();
     info!(port = ?port);


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

🚨 Severity: MEDIUM

💡 Vulnerability: Missing Content-Security-Policy header on API endpoints.

🎯 Impact: In the event of an XSS vulnerability, a missing CSP allows malicious scripts to execute and load resources.

🔧 Fix: Added a strict 'default-src 'none'' CSP header to all API responses using tower_http::set_header::SetResponseHeaderLayer.

✅ Verification: The API endpoints now return the expected CSP header.

---
*PR created automatically by Jules for task [4732411087804101092](https://jules.google.com/task/4732411087804101092) started by @kshramt*