### PR TITLE
⚡ Bolt: Wrap EntryInfos in React.memo

### DIFF
--- a/client/src/EntryInfos.tsx
+++ b/client/src/EntryInfos.tsx
@@ -7,7 +7,9 @@ import { TotalTime } from "./TotalTime";
 import { useSelector } from "./types";
 import * as types from "./types";
 
-export const EntryInfos = (props: { node_id: types.TNodeId }) => {
+// React.memo prevents unnecessary re-renders when rendering many entries in lists/queues
+// since props (node_id) rarely change.
+export const EntryInfos = React.memo((props: { node_id: types.TNodeId }) => {
   const root = useSelector((state) => state.data.root);
   const is_root = props.node_id === root;
 
@@ -18,4 +20,5 @@ export const EntryInfos = (props: { node_id: types.TNodeId }) => {
       {is_root || <LastRange node_id={props.node_id} />}
     </div>
   );
-};
+});
+EntryInfos.displayName = "EntryInfos";


### PR DESCRIPTION
💡 What: Wrapped the EntryInfos component in React.memo() and added a displayName property.

🎯 Why: EntryInfos represents purely informational display data for items (TotalTime, LastRange, etc.) and does not depend on much changing state outside of Redux selectors for a specific node_id. Since it's heavily used within virtualized list representations (like QueueEntry which is rendered hundreds of times), wrapping it prevents potentially wasteful re-renders.

📊 Impact: Reduces unnecessary React rendering cycles in the tree and queue views whenever parent state changes but the specific item's props remain identical.

🔬 Measurement: Profile React renders in devtools. Toggling items in lists should show fewer overall re-renders across unaffected sibling items.

---
*PR created automatically by Jules for task [16661754502854101822](https://jules.google.com/task/16661754502854101822) started by @kshramt*