### PR TITLE
🎨 Palette: Add accessibility attributes and tooltips to start/stop buttons

### DIFF
--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StopButton/index.tsx
+++ b/client/src/StopButton/index.tsx
@@ -19,7 +19,8 @@ const StopButton = ({
   return (
     <button
       className="btn-icon"
-      aria-label="Stop."
+      aria-label="Stop"
+      title="Stop"
       onClick={on_click}
       ref={ref}
       onDoubleClick={utils.prevent_propagation}


### PR DESCRIPTION
🎨 Palette: Add accessibility attributes and tooltips to start/stop buttons

💡 What: Added aria-labels and titles to Start, Start Concurrent, and Stop buttons.
🎯 Why: These are icon-only buttons that lack context for screen readers and lack tooltips for sighted users. Adding these attributes improves accessibility and provides helpful tooltips.
📸 Before/After: Before, buttons had no tooltips. Now they show helpful tooltips on hover.
♿ Accessibility: Added descriptive aria-labels for screen reader support.

---
*PR created automatically by Jules for task [8004253097495945128](https://jules.google.com/task/8004253097495945128) started by @kshramt*