### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/Cargo.toml
+++ b/api_v2/Cargo.toml
@@ -19,6 +19,6 @@ serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "macros", "uuid", "chrono", "json"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["full"] }
+tower-http = { version = "0.6", features = ["full", "set-header"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -388,7 +389,13 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
+
+    // Add a restrictive CSP header for defense in depth
     let app = app
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static("default-src 'none'"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
Added a restrictive CSP header (`default-src 'none'`) to the Axum application for defense in depth. Also added the `set-header` feature to `tower-http` in `api_v2/Cargo.toml` and allowed dead code on the generated module `gen` to resolve a `cargo clippy` warning.

---
*PR created automatically by Jules for task [9225857921092605302](https://jules.google.com/task/9225857921092605302) started by @kshramt*