### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/api_v2/Cargo.toml
+++ b/api_v2/Cargo.toml
@@ -19,6 +19,6 @@ serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "macros", "uuid", "chrono", "json"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["full"] }
+tower-http = { version = "0.6", features = ["full", "set-header"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod errors;
+#[allow(dead_code)]
 mod gen;
 
 struct ApiImpl;
@@ -388,8 +389,14 @@ async fn main() {
     let app = axum::Router::new();
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
+    // Sentinel: Add Content-Security-Policy to API responses to prevent XSS.
+    // The API does not serve HTML, so default-src 'none' is strictly safe.
     let app = app
         .layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static("default-src 'none'"),
+        ))
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 
     let port = get_server_port();


### PR DESCRIPTION
Added a strict 'default-src none' CSP header to the Axum router in the `api_v2` backend using `tower_http::set_header::SetResponseHeaderLayer`. This acts as defense-in-depth to prevent XSS if API endpoints were ever accessed or misinterpreted as HTML by browsers.

---
*PR created automatically by Jules for task [1467061089130176582](https://jules.google.com/task/1467061089130176582) started by @kshramt*