### PR TITLE
⚡ Bolt: Add React.memo to TreeNode component

### DIFF
--- a/client/src/components.tsx
+++ b/client/src/components.tsx
@@ -995,17 +995,20 @@ const DndTreeNode = (props: { node_id: types.TNodeId }) => {
   );
 };
 
-const TreeNode = (props: {
-  node_id: types.TNodeId;
-  prefix?: undefined | string;
-}) => {
-  return (
-    <>
-      <TreeEntry node_id={props.node_id} prefix={props.prefix} />
-      <EdgeList node_id={props.node_id} prefix={props.prefix} />
-    </>
-  );
-};
+// ⚡ Bolt Performance Optimization:
+// Wrapped TreeNode in React.memo to prevent unnecessary re-renders of the tree component structure
+// when parent components update, improving performance when navigating or updating large trees.
+const TreeNode = React.memo(
+  (props: { node_id: types.TNodeId; prefix?: undefined | string }) => {
+    return (
+      <>
+        <TreeEntry node_id={props.node_id} prefix={props.prefix} />
+        <EdgeList node_id={props.node_id} prefix={props.prefix} />
+      </>
+    );
+  },
+);
+TreeNode.displayName = "TreeNode";
 
 const NonTodoQueueNodes = (props: {
   virtuosoRef: React.Ref<Rv.VirtuosoHandle>;


### PR DESCRIPTION
Wrapped the `TreeNode` component in `client/src/components.tsx` with `React.memo` to optimize performance. 

💡 **What**: Added `React.memo` around `TreeNode` and attached a `.displayName`.
🎯 **Why**: Parent components (like the main app view or node lists) updating shouldn't force this recursively nested component to unnecessarily re-render if its `node_id` and `prefix` remain the same.
📊 **Impact**: Reduces the React rendering workload, especially important when viewing or manipulating large tree structures in the UI. 
🔬 **Measurement**: Expected to see fewer re-renders in React DevTools Profiler when interacting with sibling components or parents that update without changing this tree node's props.

---
*PR created automatically by Jules for task [17078201181689046926](https://jules.google.com/task/17078201181689046926) started by @kshramt*