### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and titles to icon-only action buttons

### DIFF
--- a/client/src/AddButton.tsx
+++ b/client/src/AddButton.tsx
@@ -29,6 +29,8 @@ export const AddButton = (props: {
     <button
       className="btn-icon"
       id={props.id}
+      aria-label="Add"
+      title="Add"
       onClick={handle_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartButton/index.tsx
+++ b/client/src/StartButton/index.tsx
@@ -15,6 +15,8 @@ const StartButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start"
+      title="Start"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/StartConcurrentButton/index.tsx
+++ b/client/src/StartConcurrentButton/index.tsx
@@ -15,6 +15,8 @@ const StartConcurrentButton = (props: { node_id: types.TNodeId }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Start concurrently"
+      title="Start concurrently"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
     >

--- a/client/src/TopButton/index.tsx
+++ b/client/src/TopButton/index.tsx
@@ -13,6 +13,8 @@ const TopButton = (props: { node_id: types.TNodeId; disabled?: boolean }) => {
   return (
     <button
       className="btn-icon"
+      aria-label="Move to top"
+      title="Move to top"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
       disabled={props.disabled}


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add ARIA labels and titles to icon-only action buttons

💡 What:
Add aria-label and title attributes to Start, StartConcurrent, Add, and Top buttons.

🎯 Why:
To improve accessibility for screen readers and provide tooltips on hover for icon-only buttons, making the interface more intuitive and compliant.

📸 Before/After:
Before: Icon-only buttons with no labels or tooltips.
After: Buttons have native tooltips on hover and are accessible to screen readers.

♿ Accessibility:
Added standard aria-labels and titles to provide accessible names for non-text interactive elements.

---
*PR created automatically by Jules for task [3295566748422923516](https://jules.google.com/task/3295566748422923516) started by @kshramt*