### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to status buttons

### DIFF
--- a/client/src/DoneOrDontToTodoButton.tsx
+++ b/client/src/DoneOrDontToTodoButton.tsx
@@ -16,6 +16,8 @@ export const DoneOrDontToTodoButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      title="Revert to todo"
+      aria-label="Revert to todo"
     >
       {consts.UNDO_MARK}
     </button>

--- a/client/src/TodoToDoneButton.tsx
+++ b/client/src/TodoToDoneButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDoneButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      title="Mark as done"
+      aria-label="Mark as done"
     >
       {consts.DONE_MARK}
     </button>

--- a/client/src/TodoToDontButton.tsx
+++ b/client/src/TodoToDontButton.tsx
@@ -18,6 +18,8 @@ export const TodoToDontButton = (props: { node_id: types.TNodeId }) => {
       className="btn-icon"
       onClick={on_click}
       onDoubleClick={utils.prevent_propagation}
+      title="Mark as won't do"
+      aria-label="Mark as won't do"
     >
       {consts.DONT_MARK}
     </button>


### PR DESCRIPTION
🎨 Palette: Add tooltips and ARIA labels to status buttons

💡 What: Added `title` and `aria-label` attributes to the status transition buttons (Mark as done, Mark as won't do, Revert to todo).
🎯 Why: These are icon-only buttons. Adding ARIA labels makes them accessible to screen readers, and adding tooltips helps sighted users understand their function before clicking.
📸 Before/After: Not applicable (invisible attribute changes except for native tooltips on hover).
♿ Accessibility: Screen reader users can now understand the purpose of the status toggle buttons via their ARIA labels.

---
*PR created automatically by Jules for task [8057565932040967427](https://jules.google.com/task/8057565932040967427) started by @kshramt*