### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-08-10 - Add Content-Security-Policy to API Responses
+**Vulnerability:** The API lacks a strict Content-Security-Policy (CSP) header, allowing potential content injection if endpoints are improperly handled by a browser.
+**Learning:** Security headers like CSP are just as critical for APIs to enforce the "defense in depth" strategy and protect against MIME-sniffing or unexpected rendering in browsers.
+**Prevention:** Implement `tower_http::set_header::SetResponseHeaderLayer` universally in the backend to ensure headers are applied safely without explicitly returning them in every response.

--- a/api_v2/src/main.rs
+++ b/api_v2/src/main.rs
@@ -389,6 +389,11 @@ async fn main() {
     let app = gen::register_app::<ApiImpl>(app);
     let app = app.with_state(state);
     let app = app
+        // 🛡️ Sentinel: Enforce strict CSP to prevent malicious content execution if an API response is improperly handled by a browser.
+        .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static("default-src 'none'"),
+        ))
         .layer(tower_http::trace::TraceLayer::new_for_http())
         .layer(axum::extract::DefaultBodyLimit::max(40 * 1024 * 1024));
 


### PR DESCRIPTION
Adds a strict Content-Security-Policy (`default-src 'none'`) to the `/api/v2/` backend to defend against potential content injection if API endpoints are accidentally rendered in a browser. This supplements existing Nginx rules for HTML content.

---
*PR created automatically by Jules for task [65113446326675670](https://jules.google.com/task/65113446326675670) started by @kshramt*